### PR TITLE
Fixed typo in example ConversationIndexFieldName value

### DIFF
--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -80,7 +80,7 @@
              - Ideally you'll create a dedicated field for this rather than overloading an existing one, to avoid other
                people/tools overwriting it with unrelated data. You should also consider not adding the field to the work
                item editing form (since no one should be editing it manually) -->
-        <ConversationIndexFieldName>ConverstionID</ConversationIndexFieldName>
+        <ConversationIndexFieldName>ConversationID</ConversationIndexFieldName>
 
         <!-- 'DefaultFieldValues' defines all the deafult values that should be assigned to the work item fields, one
              DefaultValueDefinition item per field.

--- a/Documentation/Mail2BugConfigExample.xml
+++ b/Documentation/Mail2BugConfigExample.xml
@@ -16,7 +16,7 @@
              you'll create a dedicated field for this rather than overloading an existing one, to avoid
              other people/tools overwriting it with unrelated data. Also, by making it dedicated, you can
              also make the decision to make it invisible (since no one should be editing it manually)-->
-        <ConversationIndexFieldName>ConverstionID</ConversationIndexFieldName>
+        <ConversationIndexFieldName>ConversationID</ConversationIndexFieldName>
         <DefaultFieldValues>
           <!-- The important part is to include a default value for every mandatory field, otherwise work
                item creation will fail. The only automatically defined default is the 'Title' field, that gets


### PR DESCRIPTION
Value of the ConversationIndexFieldName as given in the simple and fully annotated configs was previously "ConverstionID".  This commit changes it to "ConversationID".