### PR TITLE
Add comment to work item together with information about the sender

### DIFF
--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -103,9 +103,12 @@
                - Subject - The email subject
                - MessageBody - The body of the email message converted to plain text (i.e. if the body was HTML,
                                it would be stripped to plain text)
-               - MessageBodyWithSender - Similar to MessageBody, but with an added line at the bottom mentioning the
+               - MessageBodyWithSender - Similar to MessageBody, but with an added line at the top mentioning the
                  display name and email address of the sender. Useful to include indication of the person whose email
                  triggered the work item creation
+               - MessageLastReply - Last reply of the thread
+               - MessageLastReplyWithSender - Similar to MessageLastReply, but with an added line at the top mentioning the
+                 display name and email address of the sender.
                - RawMessageBody - The raw body of the email - i.e. if it's an HTML message, this would be the full
                  message HTML
                - Now - Current date time in general ("g") date time format (see 
@@ -126,6 +129,16 @@
           <DefaultValueDefinition Field="Iteration Path" Value="HelloWorldProject\Iteration 42" />
           <DefaultValueDefinition Field="Description" Value="##MessageBody" />
         </DefaultFieldValues>
+        
+        
+        <!--
+            DefaultFieldValuesOnUpdate is analogous to DefaultFieldValues, the values are used when an update is made
+            to an existing work item. There are no mandatory fields for this setting.
+        -->
+        <DefaultFieldValuesOnUpdate>
+            <!-- Last reply is set as comment, together with the information about the sender -->
+            <DefaultValueDefinition Field="History" Value="##MessageLastReplyWithSender" />
+        </DefaultFieldValuesOnUpdate>
         <!--  Mnemonics allow you to define short strings that users can put in the email to set specific fields to
               predefined values without the need for verbose explicit overrides. A single mnemonic can set one specific
               field, or several fieds. To have a single mnemonic set several fields, just add multiple MnemonicDefinition

--- a/Documentation/Mail2BugConfigExample.xml
+++ b/Documentation/Mail2BugConfigExample.xml
@@ -27,6 +27,9 @@
           <DefaultValueDefinition Field="Iteration Path" Value="HelloWorldProject\Iteration 42" />
           <DefaultValueDefinition Field="Description" Value="##MessageBody" />
         </DefaultFieldValues>
+        
+        <DefaultFieldValuesOnUpdate>
+        </DefaultFieldValuesOnUpdate>
         <!-- 'true' means we should attached the email message that triggered the creation of the work item -->
         <AttachOriginalMessage>true</AttachOriginalMessage>
       </WorkItemSettings>

--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -91,6 +91,7 @@ namespace Mail2Bug
 
 			public string ConversationIndexFieldName { get; set; }
 			public List<DefaultValueDefinition> DefaultFieldValues { get; set; }
+            public List<DefaultValueDefinition> DefaultFieldValuesOnUpdate { get; set; }
             public List<MnemonicDefinition> Mnemonics { get; set; }
             public List<RecipientOverrideDefinition> RecipientOverrides { get; set; }
             public List<DateBasedFieldOverrides> DateBasedOverrides { get; set; }

--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -13,6 +13,8 @@ namespace Mail2Bug.MessageProcessingStrategies
 
         public const string SubjectKeyword = "##Subject";
         public const string SenderKeyword = "##Sender";
+        public const string MessageLastReplyKeyword = "##MessageLastReply";
+        public const string MessageLastReplyWithSenderKeyword = "##MessageLastReplyWithSender";
         public const string MessageBodyKeyword = "##MessageBody";
         public const string MessageBodyWithSenderKeyword = "##MessageBodyWithSender";
         public const string RawMessageBodyKeyword = "##RawMessageBody";
@@ -30,12 +32,12 @@ namespace Mail2Bug.MessageProcessingStrategies
             _valueResolutionMap = new Dictionary<string, string>();
             _valueResolutionMap[SubjectKeyword] = GetValidSubject(message);
             _valueResolutionMap[SenderKeyword] = GetSender(message);
+            _valueResolutionMap[MessageLastReplyKeyword] = TextUtils.FixLineBreaks(message.GetLastMessageText());
+            _valueResolutionMap[MessageLastReplyWithSenderKeyword] =
+                GetMessageWithSender(_valueResolutionMap[MessageLastReplyKeyword], message.SenderName, message.SenderAddress);
             _valueResolutionMap[MessageBodyKeyword] = TextUtils.FixLineBreaks(message.PlainTextBody);
             _valueResolutionMap[MessageBodyWithSenderKeyword] =
-                String.Format("{0}\n\nCreated by: {1} ({2})", 
-                _valueResolutionMap[MessageBodyKeyword], 
-                message.SenderName, 
-                message.SenderAddress);
+                GetMessageWithSender(_valueResolutionMap[MessageBodyKeyword], message.SenderName, message.SenderAddress);
             _valueResolutionMap[RawMessageBodyKeyword] = TextUtils.FixLineBreaks(message.RawBody);
             _valueResolutionMap[NowKeyword] = DateTime.Now.ToString("g");
             _valueResolutionMap[TodayKeyword] = DateTime.Now.ToString("d");
@@ -89,6 +91,13 @@ namespace Mail2Bug.MessageProcessingStrategies
         private static string GetValidSubject(IIncomingEmailMessage message)
         {
             return !string.IsNullOrEmpty(message.ConversationTopic) ? message.ConversationTopic : "NO SUBJECT";
+        }
+
+        private static string GetMessageWithSender(string message, string sender, string senderAddress)
+        {
+            var formatted = string.Format("Created by: {1} ({2})\n\n{0}", message, sender, senderAddress);
+
+            return formatted;
         }
 
         private string GetValidTimeString(DateTime? dateTime)

--- a/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
@@ -16,9 +16,8 @@ namespace Mail2Bug.WorkItemManagement
         int CreateWorkItem(Dictionary<string, string> values);
 
         /// <param name="workItemId">The ID of the bug to modify </param>
-        /// <param name="comment">Comment to add to description</param>
         /// <param name="values">List of fields to change</param>
-        void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values);
+        void ModifyWorkItem(int workItemId, Dictionary<string, string> values);
 
         INameResolver GetNameResolver();
     }

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -241,9 +241,8 @@ namespace Mail2Bug.WorkItemManagement
         }
 
         /// <param name="workItemId">The ID of the work item to modify </param>
-        /// <param name="comment">Comment to add to description</param>
         /// <param name="values">List of fields to change</param>
-        public void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values)
+        public void ModifyWorkItem(int workItemId, Dictionary<string, string> values)
         {
             if (workItemId <= 0) return;
 
@@ -251,7 +250,6 @@ namespace Mail2Bug.WorkItemManagement
 
             workItem.Open();
 
-            workItem.History = comment.Replace("\n", "<br>");
             foreach (var key in values.Keys)
             {
                 TryApplyFieldValue(workItem, key, values[key]);
@@ -373,9 +371,9 @@ namespace Mail2Bug.WorkItemManagement
                     return;
                 }
 
-                if (field.FieldDefinition.FieldType == FieldType.Html)
+                if (field.FieldDefinition.FieldType == FieldType.Html || field.FieldDefinition.FieldType == FieldType.History)
                 {
-                    value = value.Replace("\n", "<br>");
+                    value = value.Replace("\n", "<br />");
                 }
 
                 field.Value = value;

--- a/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
+++ b/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
@@ -74,7 +74,7 @@ namespace Mail2Bug.WorkItemManagement
             return id;
         }
 
-        public void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values)
+        public void ModifyWorkItem(int workItemId, Dictionary<string, string> values)
         {
             if (ThrowOnModifyBug != null) throw ThrowOnModifyBug;
 
@@ -89,13 +89,6 @@ namespace Mail2Bug.WorkItemManagement
             {
                 bugEntry[key] = values[key];
             }
-
-            if (!bugEntry.ContainsKey(HistoryField))
-            {
-                bugEntry[HistoryField] = "";
-            }
-
-            bugEntry[HistoryField] += comment;
         }
 
         public INameResolver GetNameResolver()

--- a/Mail2BugUnitTests/SimpleBugStrategyUnitTest.cs
+++ b/Mail2BugUnitTests/SimpleBugStrategyUnitTest.cs
@@ -84,7 +84,7 @@ namespace Mail2BugUnitTests
             ValidateBugValue(bugValues, nowField, DateTime.Now.ToString("g"));
             ValidateBugValue(bugValues, todayField, DateTime.Now.ToString("d"));
             ValidateBugValue(bugValues, messageBodyField, message.PlainTextBody);
-            ValidateBugValue(bugValues, messageBodyWithSenderField, String.Format("{0}\n\nCreated by: {1} ({2})", message.PlainTextBody, message.SenderName, message.SenderAddress));
+            ValidateBugValue(bugValues, messageBodyWithSenderField, String.Format("Created by: {1} ({2})\n\n{0}", message.PlainTextBody, message.SenderName, message.SenderAddress));
             ValidateBugValue(bugValues, senderField, message.SenderName);
             ValidateBugValue(bugValues, subjectField, message.ConversationTopic);
         }
@@ -201,7 +201,7 @@ namespace Mail2BugUnitTests
             {
                 expectedValues["Changed By"] = message3.SenderName;
             }
-            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText());
+            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(message3.GetLastMessageText());
 
             ValidateBugValues(expectedValues, bugFields);
         }
@@ -249,7 +249,7 @@ namespace Mail2BugUnitTests
 
             expectedValues["Changed By"] = message4.SenderName;
             expectedValues[WorkItemManagerMock.HistoryField] = 
-                TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText() + message4.GetLastMessageText());
+                TextUtils.FixLineBreaks(message4.GetLastMessageText());
             expectedValues[mnemonicDef.Field] = mnemonicDef.Value;
             expectedValues[explicitOverride1.Key] = explicitOverride1.Value;
 
@@ -284,7 +284,7 @@ namespace Mail2BugUnitTests
 
             expectedValues["Changed By"] = message3.SenderName;
             expectedValues[WorkItemManagerMock.HistoryField] = 
-                TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText());
+                TextUtils.FixLineBreaks(message3.GetLastMessageText());
 
             ValidateBugValues(expectedValues, bugFields);
 

--- a/Mail2BugUnitTests/SimpleBugStrategyUnitTestConfig.xml
+++ b/Mail2BugUnitTests/SimpleBugStrategyUnitTestConfig.xml
@@ -14,6 +14,9 @@
         <DefaultFieldValues>
           <DefaultValueDefinition Field="Assigned To" Value="ABCD" />
         </DefaultFieldValues>
+        <DefaultFieldValuesOnUpdate>
+          <DefaultValueDefinition Field="History" Value="##MessageLastReply" />
+        </DefaultFieldValuesOnUpdate>
       </WorkItemSettings>
       <EmailSettings>
         <ServiceType>EWSByRecipients</ServiceType>


### PR DESCRIPTION
This introduces two new special values (##MessageLastReply and ##MessageLastReplyWithSender) and a new configuration option DefaultFieldValuesOnUpdate. DefaultFieldValuesOnUpdate is same as DefaultFieldValues except that its default values are used when an update is applied to a work item. ##MessageLastReplyWithSender allows to set the default value for field History similarly as is currently done for Description with ##MessageBodyWithSender. This change also unifies the code a bit as we do not need to have special cases for History field. It should also allow to remove the configuration option OverrideChangedBy and replace it with ##Sender as default value for 'Changed By' on update.

