### PR TITLE
Add a few convience items for message text and processing

### DIFF
--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -121,6 +121,8 @@
                  triggered the work item creation
                - RawMessageBody - The raw body of the email - i.e. if it's an HTML message, this would be the full
                  message HTML
+               - RawMessageBodyWithSender - The raw body of the email prepended with the display name and email address - i.e. if it's an HTML message, this would be the full
+                 message HTML
                - Now - Current date time in general ("g") date time format (see 
                  https://msdn.microsoft.com/en-us/library/az4se3k1%28v=vs.110%29.aspx for date time format specification)
                - Today - Current date in short date format ("d")
@@ -203,6 +205,11 @@
         <!-- 'AttachUpdateMessages' - 'true' means we should attach "reply" emails that update the work item 
              The default is 'false', since this can add considerable data size load to the work item -->
         <AttachUpdateMessages>false</AttachUpdateMessages>
+
+        <!-- 'AddFromHeadertoTextOnUpdate ' - 'true' means we should prepend "'sender name' ('alias') said:" during updates to work item 
+             The default is 'false'-->
+        <AddFromHeadertoTextOnUpdate >false</AddFromHeadertoTextOnUpdate >
+
 
       </WorkItemSettings>
 

--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -85,7 +85,8 @@ namespace Mail2Bug
 		        ApplyOverridesDuringUpdate = true;
 		        AttachOriginalMessage = true;
                 AttachUpdateMessages = false;
-		    }
+                AddFromHeadertoTextOnUpdate = false;
+            }
 
             public enum ProcessingStrategyType
             {
@@ -102,8 +103,10 @@ namespace Mail2Bug
             public bool ApplyOverridesDuringUpdate { get; set; }
             public bool AttachOriginalMessage { get; set; }
 		    public bool AttachUpdateMessages { get; set; }
+            public bool AddFromHeadertoTextOnUpdate { get; set; }
 
-		    public ProcessingStrategyType ProcessingStrategy = ProcessingStrategyType.SimpleBugStrategy;
+
+            public ProcessingStrategyType ProcessingStrategy = ProcessingStrategyType.SimpleBugStrategy;
 		}
 
 		public class DefaultValueDefinition

--- a/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
@@ -42,6 +42,8 @@ namespace Mail2Bug.Email.EWS
         public string RawBody { get { return _message.Body.Text ?? string.Empty; } }
         public string PlainTextBody { get { return GetPlainTextBody(_message); } }
 
+        public string RawReplyBody { get { var reply = _message.CreateReply(false); var replyMessage = reply.Save(WellKnownFolderName.Drafts);  replyMessage.Load();  replyMessage.Delete(DeleteMode.HardDelete);  return replyMessage.Body.Text ?? string.Empty; } }
+
         public string ConversationIndex
         {
             get { return string.Join("", _message.ConversationIndex.Select(b => b.ToString("X2"))); }

--- a/Mail2Bug/Email/IIncomingEmailMessage.cs
+++ b/Mail2Bug/Email/IIncomingEmailMessage.cs
@@ -14,6 +14,7 @@ namespace Mail2Bug.Email
     {
         string Subject { get; }
         string RawBody { get; }
+        string RawReplyBody { get; }
         string PlainTextBody { get; }
         string ConversationIndex { get; }
         string ConversationTopic { get; }

--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -16,7 +16,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public const string MessageBodyKeyword = "##MessageBody";
         public const string MessageBodyWithSenderKeyword = "##MessageBodyWithSender";
         public const string RawMessageBodyKeyword = "##RawMessageBody";
-        public const string RawMessageBodyWithSenderKeyword = "##RawMessageBodyWithSender";
+        public const string RawMessageBodyFromReply = "##RawMessageBodyFromReply";
         public const string NowKeyword = "##Now";
         public const string TodayKeyword = "##Today";
         public const string LocationKeyword = "##Location";
@@ -38,11 +38,7 @@ namespace Mail2Bug.MessageProcessingStrategies
                 message.SenderName, 
                 message.SenderAddress);
             _valueResolutionMap[RawMessageBodyKeyword] = TextUtils.FixLineBreaks(message.RawBody);
-            _valueResolutionMap[RawMessageBodyWithSenderKeyword] =
-             String.Format("Created by: {1} ({2})\n\n{0}",
-             TextUtils.FixLineBreaks(message.RawBody),
-             message.SenderName,
-             message.SenderAddress);
+            _valueResolutionMap[RawMessageBodyFromReply] = TextUtils.FixLineBreaks(message.RawReplyBody);
             _valueResolutionMap[NowKeyword] = DateTime.Now.ToString("g");
             _valueResolutionMap[TodayKeyword] = DateTime.Now.ToString("d");
             _valueResolutionMap[LocationKeyword] = message.Location;

--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -16,6 +16,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public const string MessageBodyKeyword = "##MessageBody";
         public const string MessageBodyWithSenderKeyword = "##MessageBodyWithSender";
         public const string RawMessageBodyKeyword = "##RawMessageBody";
+        public const string RawMessageBodyWithSenderKeyword = "##RawMessageBodyWithSender";
         public const string NowKeyword = "##Now";
         public const string TodayKeyword = "##Today";
         public const string LocationKeyword = "##Location";
@@ -37,6 +38,11 @@ namespace Mail2Bug.MessageProcessingStrategies
                 message.SenderName, 
                 message.SenderAddress);
             _valueResolutionMap[RawMessageBodyKeyword] = TextUtils.FixLineBreaks(message.RawBody);
+            _valueResolutionMap[RawMessageBodyWithSenderKeyword] =
+             String.Format("Created by: {1} ({2})\n\n{0}",
+             TextUtils.FixLineBreaks(message.RawBody),
+             message.SenderName,
+             message.SenderAddress);
             _valueResolutionMap[NowKeyword] = DateTime.Now.ToString("g");
             _valueResolutionMap[TodayKeyword] = DateTime.Now.ToString("d");
             _valueResolutionMap[LocationKeyword] = message.Location;

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -412,9 +412,10 @@ namespace Mail2Bug.WorkItemManagement
                     return;
                 }
 
-                if (field.FieldDefinition.FieldType == FieldType.Html)
+                if (field.FieldDefinition.FieldType == FieldType.Html
+                     && !value.StartsWith("<html"))  // don't replace \n in a value with real html content, it must not be interpreted!
                 {
-                    value = value.Replace("\n", "<br>");
+                      value = value.Replace("\n", "<br>");
                 }
 
                 field.Value = value;

--- a/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
@@ -64,6 +64,7 @@ namespace Mail2BugUnitTests.Mocks.Email
 
         public string Subject { get; set; }
         public string RawBody { get; set; }
+        public string RawReplyBody { get; set; }
         public string PlainTextBody { get; set; }
         public string ConversationIndex { get; set; }
         public string ConversationTopic { get; set; }


### PR DESCRIPTION
Adding AddFromHeadertoTextOnUpdate config item to prepend sender information on update text

Adding Resolve during override application on UpdateWorkItem.  Enables:           
MnemonicDefinition Mnemonic="Gimmie" Field="Assigned To" Value="##Sender" 

Adding ##RawMessageBodyWithSender option to get sender information on the first screen in VSO