### PR TITLE
try silent auth before allowing a prompt

### DIFF
--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -94,6 +94,7 @@ namespace Mail2Bug.WorkItemManagement
             credentials.AddRange(GetServiceIdentityCredentials());
             credentials.AddRange(GetServiceIdentityPatCredentials());
             credentials.AddRange(GetBasicAuthCredentials());
+            credentials.Add(new TfsClientCredentials(new WindowsCredential(false), false));
             credentials.Add(new TfsClientCredentials(true));
 
             return credentials;


### PR DESCRIPTION
The last fallback auth attempt is the ambient credentials. This change will nudge the authentication system to try without prompting first. That's what it took to get it running under a service account in my implementation.