### PR TITLE
Open bugs on behalf of the sender of first email

### DIFF
--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -196,6 +196,12 @@
              to fail.  -->
         <OverrideChangedBy>true</OverrideChangedBy>
 
+        <!-- 'OverrideCreatedBy' - 'true' means we should set the value of "Created By" to the user who sent the email,
+             such that work item would appear as "created by ...". Since this field may be read only (depending on
+             the server side configuration), this config allows you to turn it off, to avoid causing the the work item
+             to fail.  -->
+        <OverrideCreatedBy>true</OverrideCreatedBy>
+
         <!-- 'AttachOriginalMessage' - 'true' means we should attach the email message that triggered the creation
              of the work item -->
         <AttachOriginalMessage>true</AttachOriginalMessage>

--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -82,6 +82,7 @@ namespace Mail2Bug
             public WorkItemSettings()
 		    {
 		        OverrideChangedBy = true;
+                OverrideCreatedBy = true;
 		        ApplyOverridesDuringUpdate = true;
 		        AttachOriginalMessage = true;
                 AttachUpdateMessages = false;
@@ -99,6 +100,7 @@ namespace Mail2Bug
             public List<DateBasedFieldOverrides> DateBasedOverrides { get; set; }
 
             public bool OverrideChangedBy { get; set; }
+            public bool OverrideCreatedBy { get; set; }
             public bool ApplyOverridesDuringUpdate { get; set; }
             public bool AttachOriginalMessage { get; set; }
 		    public bool AttachUpdateMessages { get; set; }

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -105,7 +105,7 @@ namespace Mail2Bug.MessageProcessingStrategies
 
             if (_config.WorkItemSettings.OverrideCreatedBy)
             {
-                workItemUpdates["Created By"] = message.SenderAddress;
+                workItemUpdates["Created By"] = resolver.Sender;
             }
         }
 

--- a/Mail2BugUnitTests/SimpleBugStrategyUnitTest.cs
+++ b/Mail2BugUnitTests/SimpleBugStrategyUnitTest.cs
@@ -168,12 +168,18 @@ namespace Mail2BugUnitTests
         }
 
         [TestMethod]
+        public void TestProcessingEmailThreadOverrideCreatedBy()
+        {
+            TestProcessingEmailThreadImpl(false, true);
+        }
+
+        [TestMethod]
         public void TestProcessingEmailThreadDontOverrideChangedBy()
         {
             TestProcessingEmailThreadImpl(false);
         }
 
-        public void TestProcessingEmailThreadImpl(bool overrideChangedBy)
+        public void TestProcessingEmailThreadImpl(bool overrideChangedBy, bool overrideCreatedBy = false)
         {
             var seed = _rand.Next();
 
@@ -201,6 +207,12 @@ namespace Mail2BugUnitTests
             {
                 expectedValues["Changed By"] = message3.SenderName;
             }
+
+            if (overrideCreatedBy)
+            {
+                expectedValues["Created By"] = message1.SenderAddress;
+            }
+
             expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText());
 
             ValidateBugValues(expectedValues, bugFields);


### PR DESCRIPTION
Adding a config value similar to OverrideChangedBy to automatically
use the SenderAddress as "Created By"

Note: "Created By" is a read only field, just as "Changed By" and server
needs to be configured to BypassRules to support this

Fixes #29 