### PR TITLE
Use Exchange plain-text body property to fix HTML-to-text conversions

### DIFF
--- a/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
@@ -11,12 +11,14 @@ namespace Mail2Bug.Email.EWS
     public class EWSIncomingMessage : IIncomingEmailMessage
     {
         private const int PidTagBodyHtmlTag = 0x1013;
-
         private const int PidTagConversationIdTag = 0x3013;
 
         private readonly EmailMessage _message;
         private readonly byte[] _conversationId;
         private readonly bool _useConversationGuidOnly;
+
+        // Extended property for PidTagBodyHtmlTag, which is the HTML body of the Message object
+        // See https://msdn.microsoft.com/en-us/library/ee202050(v=exchg.80).aspx
         private static readonly ExtendedPropertyDefinition PidTagBodyHtml = new ExtendedPropertyDefinition(PidTagBodyHtmlTag, MapiPropertyType.Binary);
 
         public EWSIncomingMessage(EmailMessage message, bool useConversationGuidOnly = false)


### PR DESCRIPTION
ConvertHtmlMessageToPlainText doesn't always do a good job of converting HTML to plain-text.
For example, the following HTML "###Assigned <span class=spelle>To:Test Account</span>" comes in with line breaks at the beginning of tags in Body.Text:
### Assigned

<span class=spelle>To:Danny Khen</span>

This translates into "Assigned\r\n To" tag name, which is incorrect. 
This change switches Body property to be plain-text, so conversion is done in Exchange.
Additionally requesting PR_BODY_HTML to return original HTML representation in the RawBody property.
