### PR TITLE
Allow local machine encryption

### DIFF
--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -78,7 +78,12 @@ namespace Mail2Bug
 		    public string OAuthContext { get; set; }
 		    public string OAuthResourceId { get; set; }
 		    public string OAuthClientId { get; set; }
-		}
+
+            /// <summary>
+            /// If true we will need to use the machine scope
+            /// </summary>
+            public bool UseMachineScopeEncryption { get; set; }
+        }
 
 		public class WorkItemSettings
 		{
@@ -224,6 +229,11 @@ namespace Mail2Bug
             // contain timestamps or additional reply information.
             // See https://msdn.microsoft.com/en-us/library/ee202481(v=exchg.80).aspx for more information
             public bool UseConversationGuidOnly { get; set; }
+
+            /// <summary>
+            /// If true we will need to use the machine scope
+            /// </summary>
+            public bool UseMachineScopeEncryption { get; set; }
 
             private string _replyTemplate;
 		}

--- a/Mail2Bug/Email/MailboxManagerFactory.cs
+++ b/Mail2Bug/Email/MailboxManagerFactory.cs
@@ -19,11 +19,12 @@ namespace Mail2Bug.Email
 
         public IMailboxManager CreateMailboxManager(Config.EmailSettings emailSettings)
         {
+            var scope = emailSettings.UseMachineScopeEncryption ? System.Security.Cryptography.DataProtectionScope.LocalMachine : System.Security.Cryptography.DataProtectionScope.CurrentUser;
             var credentials = new EWSConnectionManger.Credentials
             {
                 EmailAddress = emailSettings.EWSMailboxAddress,
                 UserName = emailSettings.EWSUsername,
-                Password = DPAPIHelper.ReadDataFromFile(emailSettings.EWSPasswordFile)
+                Password = DPAPIHelper.ReadDataFromFile(emailSettings.EWSPasswordFile, scope)
             };
 
             var exchangeService = _connectionManger.GetConnection(credentials, emailSettings.UseConversationGuidOnly);

--- a/Mail2Bug/Helpers/DPAPIHelper.cs
+++ b/Mail2Bug/Helpers/DPAPIHelper.cs
@@ -7,12 +7,16 @@ namespace Mail2Bug.Helpers
 {
     public class DPAPIHelper
     {
-        public static void WriteDataToFile(string data, string filename)
+        /// <summary>
+        /// Writes string data to target file name using specified data protection scope
+        /// </summary>
+        /// <param name="data">string to encrypt</param>
+        /// <param name="filename">filename to write out to</param>
+        /// <param name="scope">scope of protection to use (user or machine)</param>
+        public static void WriteDataToFile(string data, string filename, DataProtectionScope scope)
         {
-            var serializedData = Encoding.UTF8.GetBytes(data);
-
             Logger.InfoFormat("Encrypting data using DPAPI");
-            var encryptedData = ProtectedData.Protect(serializedData, null, DataProtectionScope.CurrentUser);
+            var encryptedData = Encrypt(data, null, scope);
             Logger.InfoFormat("Data encrypted successfully. Creating file {0}", filename);
 
             using (var fs = new FileStream(filename, FileMode.Create, FileAccess.ReadWrite))
@@ -23,20 +27,51 @@ namespace Mail2Bug.Helpers
             }
         }
 
-        public static string ReadDataFromFile(string filename)
+        /// <summary>
+        /// Reads encrypted string data from source filename that was encrypted with specified scope scheme
+        /// </summary>
+        /// <param name="filename">Path to source file</param>
+        /// <param name="scope">scope of protection of souce file</param>
+        /// <returns></returns>
+        public static string ReadDataFromFile(string filename, DataProtectionScope scope)
         {
             Logger.InfoFormat("Reading encrypted data from file {0}", filename);
             using (var fs = new FileStream(filename, FileMode.Open, FileAccess.ReadWrite))
             {
                 var encryptedData = new byte[fs.Length];
                 fs.Read(encryptedData, 0, encryptedData.Length);
-                var serializedData = ProtectedData.Unprotect(encryptedData, null, DataProtectionScope.CurrentUser);
-                var data = Encoding.UTF8.GetString(serializedData);
+                var data = Decrypt(encryptedData, null, scope);
 
                 return data;
             }
         }
 
-        private static readonly ILog Logger = LogManager.GetLogger(typeof (DPAPIHelper));
+
+        /// <summary>
+        /// Assumes UTF8 and encodes using DPAPI
+        /// </summary>
+        /// <param name="stringToEncrypt">string to encrypt</param>
+        /// <param name="optionalEntropy">optional entropy to include</param>
+        /// <param name="scope">scope of protection</param>
+        /// <returns></returns>
+        public static byte[] Encrypt(string stringToEncrypt, byte[] optionalEntropy, DataProtectionScope scope)
+        {
+            return ProtectedData.Protect(Encoding.UTF8.GetBytes(stringToEncrypt), optionalEntropy, scope);
+        }
+
+
+        /// <summary>
+        /// Assumes UTF8 and decodes using DPAPI
+        /// </summary>
+        /// <param name="encryptedData">encrypted data</param>
+        /// <param name="optionalEntropy">optional entropy that was used during encryption</param>
+        /// <param name="scope">scope of protection</param>
+        /// <returns></returns>
+        public static string Decrypt(byte[] encryptedData, byte[] optionalEntropy, DataProtectionScope scope)
+        {
+            return Encoding.UTF8.GetString(ProtectedData.Unprotect(encryptedData, optionalEntropy, scope));
+        }
+
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(DPAPIHelper));
     }
 }

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -182,8 +182,10 @@ namespace Mail2Bug.WorkItemManagement
                 throw new BadConfigException("AltAuthPasswordFile", "Alt password file doesn't exist");
             }
 
+            var scope = _config.TfsServerConfig.UseMachineScopeEncryption ? System.Security.Cryptography.DataProtectionScope.LocalMachine : System.Security.Cryptography.DataProtectionScope.CurrentUser;
+
             return new Tuple<string, string>(_config.TfsServerConfig.AltAuthUsername,
-                DPAPIHelper.ReadDataFromFile(_config.TfsServerConfig.AltAuthPasswordFile));
+                DPAPIHelper.ReadDataFromFile(_config.TfsServerConfig.AltAuthPasswordFile, scope));
         }
 
         private Tuple<string,string> GetServiceIdentityUsernameAndPasswordFromConfig()
@@ -199,8 +201,10 @@ namespace Mail2Bug.WorkItemManagement
                 throw new BadConfigException("ServiceIdentityPasswordFile", "Service identity password file doesn't exist");
             }
 
+            var scope = _config.TfsServerConfig.UseMachineScopeEncryption ? System.Security.Cryptography.DataProtectionScope.LocalMachine : System.Security.Cryptography.DataProtectionScope.CurrentUser;
+
             return new Tuple<string, string>(_config.TfsServerConfig.ServiceIdentityUsername, 
-                DPAPIHelper.ReadDataFromFile(_config.TfsServerConfig.ServiceIdentityPasswordFile));
+                DPAPIHelper.ReadDataFromFile(_config.TfsServerConfig.ServiceIdentityPasswordFile, scope));
         }
 
         private IEnumerable<TfsClientCredentials> GetServiceIdentityPatCredentials()
@@ -229,7 +233,9 @@ namespace Mail2Bug.WorkItemManagement
                 throw new BadConfigException("ServiceIdentityPatFile", "Personal Access Token file doesn't exist");
             }
 
-            return DPAPIHelper.ReadDataFromFile(_config.TfsServerConfig.ServiceIdentityPatFile);
+            var scope = _config.TfsServerConfig.UseMachineScopeEncryption ? System.Security.Cryptography.DataProtectionScope.LocalMachine : System.Security.Cryptography.DataProtectionScope.CurrentUser;
+
+            return DPAPIHelper.ReadDataFromFile(_config.TfsServerConfig.ServiceIdentityPatFile, scope);
         }
 
         public void AttachFiles(int workItemId, List<string> fileList)

--- a/Mail2BugUnitTests/DPAPIUnitTests.cs
+++ b/Mail2BugUnitTests/DPAPIUnitTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mail2Bug.Helpers;
+using System.Security.Cryptography;
+using System.Security.Principal;
+
+namespace Mail2BugUnitTests
+{
+    [TestClass]
+    public class DPAPIUnitTests
+    {
+        #region Encode/Decode tests
+        [TestMethod]
+        public void TestSimpleEncryptionSucceedsDefaultScope()
+        {
+            var sourceString = "Hello world!@#";
+
+            var encryptedData = DPAPIHelper.Encrypt(sourceString, null, DataProtectionScope.CurrentUser);
+            var decryptedString = DPAPIHelper.Decrypt(encryptedData, null, DataProtectionScope.CurrentUser);
+            Assert.AreEqual<string>(sourceString, decryptedString);
+        }
+
+        [TestMethod]
+        public void TestSimpleEncryptionSucceedsMachineScope()
+        {
+            var sourceString = "Hello world!@#";
+
+            var encryptedData = DPAPIHelper.Encrypt(sourceString, null, DataProtectionScope.LocalMachine);
+            var decryptedString = DPAPIHelper.Decrypt(encryptedData, null, DataProtectionScope.LocalMachine);
+            Assert.AreEqual<string>(sourceString, decryptedString);
+        }
+
+        #endregion
+
+        #region "read" tests
+        [TestMethod]
+        public void TestCommandLineReadSimple_1()
+        {
+            var fn = "foobar.txt";
+            var cl = string.Format("read /Filename={0}", fn);
+            var command = DpapiHelperUtil.ArgumentParserHelper.ParseArguments(cl.Split(' '));
+            Assert.IsNotNull(command);
+            Assert.IsTrue(command is DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilReadCommand);
+            var typedCommand = command as DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilReadCommand;
+            Assert.AreEqual(typedCommand.Filename, fn);
+            Assert.AreEqual(typedCommand.Scope, DataProtectionScope.CurrentUser);
+        }
+
+        [TestMethod]
+        public void TestCommandLineReadSimple_2()
+        {
+            var fn = "foobar.txt";
+            var cl = string.Format("read user /Filename={0}", fn);
+            var command = DpapiHelperUtil.ArgumentParserHelper.ParseArguments(cl.Split(' '));
+            Assert.IsNotNull(command);
+            Assert.IsTrue(command is DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilReadCommand);
+            var typedCommand = command as DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilReadCommand;
+            Assert.AreEqual(typedCommand.Filename, fn);
+            Assert.AreEqual(typedCommand.Scope, DataProtectionScope.CurrentUser);
+        }
+
+        [TestMethod]
+        public void TestCommandLineReadSimple_3()
+        {
+            var fn = "foobar.txt";
+            var cl = string.Format("read machine /Filename={0}", fn);
+            var command = DpapiHelperUtil.ArgumentParserHelper.ParseArguments(cl.Split(' '));
+            Assert.IsNotNull(command);
+            Assert.IsTrue(command is DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilReadCommand);
+            var typedCommand = command as DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilReadCommand;
+            Assert.AreEqual(typedCommand.Filename, fn);
+            Assert.AreEqual(typedCommand.Scope, DataProtectionScope.LocalMachine);
+        }
+
+        #endregion
+
+        #region "write" tests
+        [TestMethod]
+        public void TestCommandLineWriteSimple_1()
+        {
+            var data = "P@ssword";
+            var fn = "foobar.txt";
+            var cl = string.Format("write /Data={0} /Out={1}", data, fn);
+            var command = DpapiHelperUtil.ArgumentParserHelper.ParseArguments(cl.Split(' '));
+            Assert.IsNotNull(command);
+            Assert.IsTrue(command is DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilWriteCommand);
+            var typedCommand = command as DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilWriteCommand;
+            Assert.AreEqual(typedCommand.Out, fn);
+            Assert.AreEqual(typedCommand.Data, data);
+            Assert.AreEqual(typedCommand.Scope, DataProtectionScope.CurrentUser);
+        }
+
+        [TestMethod]
+        public void TestCommandLineWriteSimple_2()
+        {
+            var data = "P@ssword";
+            var fn = "foobar.txt";
+            var cl = string.Format("write user /Data={0} /Out={1}", data, fn);
+            var command = DpapiHelperUtil.ArgumentParserHelper.ParseArguments(cl.Split(' '));
+            Assert.IsNotNull(command);
+            Assert.IsTrue(command is DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilWriteCommand);
+            var typedCommand = command as DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilWriteCommand;
+            Assert.AreEqual(typedCommand.Out, fn);
+            Assert.AreEqual(typedCommand.Data, data);
+            Assert.AreEqual(typedCommand.Scope, DataProtectionScope.CurrentUser);
+        }
+
+        [TestMethod]
+        public void TestCommandLineWriteSimple_3()
+        {
+            var data = "P@ssword";
+            var fn = "foobar.txt";
+            var cl = string.Format("write machine /Data={0} /Out={1}", data, fn);
+            var command = DpapiHelperUtil.ArgumentParserHelper.ParseArguments(cl.Split(' '));
+            Assert.IsNotNull(command);
+            Assert.IsTrue(command is DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilWriteCommand);
+            var typedCommand = command as DpapiHelperUtil.DpapiHelperUtilMain.DpapiUtilWriteCommand;
+            Assert.AreEqual(typedCommand.Out, fn);
+            Assert.AreEqual(typedCommand.Data, data);
+            Assert.AreEqual(typedCommand.Scope, DataProtectionScope.LocalMachine);
+        }
+
+        #endregion
+    }
+}

--- a/Mail2BugUnitTests/Mail2BugUnitTests.csproj
+++ b/Mail2BugUnitTests/Mail2BugUnitTests.csproj
@@ -44,6 +44,7 @@
       <HintPath>..\packages\Moq.4.2.1506.2016\lib\net40\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Security" />
     <Reference Include="TestApiCore">
       <HintPath>..\packages\Microsoft.TestApi.0.6.0.0\lib\net40\TestApiCore.dll</HintPath>
     </Reference>
@@ -59,7 +60,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -74,6 +77,7 @@
     <Compile Include="RecipientsMailboxManagerRouterUnitTest.cs" />
     <Compile Include="SimpleBugStrategyUnitTest.cs" />
     <Compile Include="TfsQueryParserUnitTest.cs" />
+    <Compile Include="DPAPIUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -101,6 +105,10 @@
     <ProjectReference Include="..\Mail2Bug\Mail2Bug.csproj">
       <Project>{22cb93ef-6d91-40b7-a6c9-e5f67595160e}</Project>
       <Name>Mail2Bug</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Tools\DpapiTool\DpapiTool.csproj">
+      <Project>{4788593c-88fa-4f93-85ed-681e8b165760}</Project>
+      <Name>DpapiTool</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/Tools/DpapiTool/ArgumentParserHelper.cs
+++ b/Tools/DpapiTool/ArgumentParserHelper.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Test.CommandLineParsing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using static DpapiHelperUtil.DpapiHelperUtilMain;
+
+namespace DpapiHelperUtil
+{
+
+    public static class ArgumentParserHelper
+    {
+        /// <summary>
+        /// Helper to determine and set arguments
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static Command ParseArguments(string[] args)
+        {
+            Command resultCommand = null;
+
+            // skip the "read/write" arg
+            var argsToSkip = 1;
+            DataProtectionScope scope = DataProtectionScope.CurrentUser;
+
+            // check if we have additional arguments
+            if (args.Length > 1)
+            {
+                if (args[1].Equals("machine", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    scope = DataProtectionScope.LocalMachine;
+
+                    // also skip the "machine" word
+                    argsToSkip++;
+                }
+                if (args[1].Equals("user", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // skip "user" word
+                    argsToSkip++;
+                }
+            }
+
+            if (args[0].Equals("read", StringComparison.InvariantCultureIgnoreCase))
+            {
+                resultCommand = new DpapiUtilReadCommand(scope);
+            }
+
+            if (args[0].Equals("write", StringComparison.InvariantCultureIgnoreCase))
+            {
+                resultCommand = new DpapiUtilWriteCommand(scope);
+            }
+
+            // if we have a "real" known command, then try to parse rest of the arguments. Otherwise it doesn't matter
+            if (resultCommand != null)
+                resultCommand.ParseArguments(args.Skip(argsToSkip));
+
+            return resultCommand;
+        }
+    }
+}

--- a/Tools/DpapiTool/DpapiTool.csproj
+++ b/Tools/DpapiTool/DpapiTool.csproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -50,6 +51,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentParserHelper.cs" />
     <Compile Include="DpapiHelperUtilMain.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Please review the following few changes.  Nothing should need to be updated for those already running the tool omitting specifying the type of encryption to use.
- Added argument to EmailSettings &TfsSettings to handle scope type (user vs machine)
- Refactored Encrypt/Decrypt to make functionality be unit testable
- Refactored Argument parsing in DpapiTool to make argument parsing unit testable
- Added unit tests for the above changes
