### PR TITLE
Allow @CurrentIteration; Fix RTF-format emails

### DIFF
--- a/Mail2Bug/Email/EWS/EWSExtendedProperty.cs
+++ b/Mail2Bug/Email/EWS/EWSExtendedProperty.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Exchange.WebServices.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mail2Bug.Email.EWS
+{
+    public class EWSExtendedProperty
+    {
+        private const int PidTagBodyIdentifier = 0x1000;
+        private const int PidTagConversationIdIdentifier = 0x3013;
+
+        // Extended property for PidTagBody, which is the message body converted to plain text format
+        // See https://msdn.microsoft.com/en-us/library/ee158918%28EXCHG.80%29.aspx
+        public static readonly ExtendedPropertyDefinition PidTagBody = new ExtendedPropertyDefinition(PidTagBodyIdentifier, MapiPropertyType.String);
+
+        // Extended property for PidTagConversationId, which is the GUID portion of the ConversationIndex
+        // See https://msdn.microsoft.com/en-us/library/cc433490(v=EXCHG.80).aspx and
+        // https://msdn.microsoft.com/en-us/library/ee204279(v=exchg.80).aspx for more information
+        public static readonly ExtendedPropertyDefinition PidTagConversationId = new ExtendedPropertyDefinition(PidTagConversationIdIdentifier, MapiPropertyType.Binary);
+
+    }
+}

--- a/Mail2Bug/Mail2Bug.csproj
+++ b/Mail2Bug/Mail2Bug.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Email\EmailBodyProcessingUtils.cs" />
     <Compile Include="Email\EWS\ArchiverMessagePostProcessor.cs" />
     <Compile Include="Email\EWS\EWSConnectionManger.cs" />
+    <Compile Include="Email\EWS\EWSExtendedProperty.cs" />
     <Compile Include="Email\EWS\EWSIncomingFileAttachment.cs" />
     <Compile Include="Email\EWS\EWSIncomingItemAttachment.cs" />
     <Compile Include="Email\EWS\EWSIncomingMessage.cs" />

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -281,7 +281,7 @@ namespace Mail2Bug.WorkItemManagement
                 string value = values[key];
 
                 // Resolve current iteration
-                if (_teamSettings != null && key == "Iteration Path" && value == "@CurrentIteration")
+                if (_teamSettings != null && key == IterationPathFieldKey && value == CurrentIterationSpecialValue)
                 {
                     value = _teamSettings.CurrentIterationPath;
                 }
@@ -522,7 +522,8 @@ namespace Mail2Bug.WorkItemManagement
         #region Consts
 
         private const string AssignedToFieldKey = "Assigned To";
-
+        private const string IterationPathFieldKey = "Iteration Path";
+        private const string CurrentIterationSpecialValue = "@CurrentIteration";
         #endregion
 
         private readonly WorkItemStore _tfsStore;


### PR DESCRIPTION
The first change will automatically assign the bug to the current iteration when specified in the config file:

    <DefaultValueDefinition Field="Iteration Path" Value="@CurrentIteration" />

The special value is the same one used by the query UI for VSTS.

The second change fixes a problem introduced by a previous pull request ( #41). The original pull request specified the message be returned in plain text and used an extended property to get the native HTML body. However, the native HTML body is empty for RTF format emails. I've reversed the logic to always request HTML format (EWS always succeeds in converting any native format to HTML), and use an extended property to return the plain text version (EWS always down-converts to provide this value). This achieves the same goal without the side-effect.