### PR TITLE
Enable UseConversationGuidOnly by default

### DIFF
--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -267,6 +267,13 @@
              contents. -->
         <EWSPasswordFile>.\Resources\mail2bug.bin</EWSPasswordFile>
 
+        <!-- Instead of using the whole ConversationIndex, use only the ConversationID, which is the guid portion of
+             the ConversationIndex, to identify a conversation. This should help avoid the possibility of replies
+             inadvertently spawning new bugs. See https://msdn.microsoft.com/en-us/library/ee202481(v=exchg.80).aspx
+             for more information.
+             Warning: Changing this on an existing instance will break links with bugs that it already created. -->
+        <UseConversationGuidOnly>true</UseConversationGuidOnly>
+
         <!-- 'SendAckEmails' - Should mail2bug send replies when creating new work items? -->
         <SendAckEmails>true</SendAckEmails>
 

--- a/Documentation/Mail2BugConfigExample.xml
+++ b/Documentation/Mail2BugConfigExample.xml
@@ -52,6 +52,10 @@
              run under the same credentials that mail2bug will run with, otherwise it won't be able to decrypt the
              contents. -->
         <EWSPasswordFile>.\Resources\mail2bug.bin</EWSPasswordFile>
+
+        <!-- Warning: Changing this on an existing instance will break links with bugs that it already created. -->
+        <UseConversationGuidOnly>true</UseConversationGuidOnly>
+
         <SendAckEmails>true</SendAckEmails>
         <AckEmailsRecipientsAll>true</AckEmailsRecipientsAll>
 

--- a/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
@@ -137,7 +137,7 @@ namespace Mail2Bug.Email.EWS
         public string GetConversationGuid()
         {
             return _conversationId == null
-               ? this.ConversationId.Substring(12, 32)
+               ? this.GetConversationIndex().Substring(12, 32)
                : string.Join("", _conversationId.Select(b => b.ToString("X2")));
         }
 

--- a/Mail2Bug/Email/EWS/FolderMailBoxManager.cs
+++ b/Mail2Bug/Email/EWS/FolderMailBoxManager.cs
@@ -15,12 +15,14 @@ namespace Mail2Bug.Email.EWS
         private readonly ExchangeService _service;
         private readonly string _mailFolder;
         private readonly IMessagePostProcessor _postProcessor;
+        private readonly bool _useConversationGuidOnly;
 
-        public FolderMailboxManager(ExchangeService connection, string incomingFolder, IMessagePostProcessor postProcessor)
+        public FolderMailboxManager(ExchangeService connection, string incomingFolder, IMessagePostProcessor postProcessor, bool useConversationGuidOnly)
         {
             _service = connection;
             _mailFolder = incomingFolder;
             _postProcessor = postProcessor;
+            _useConversationGuidOnly = useConversationGuidOnly;
         }
 
         public IEnumerable<IIncomingEmailMessage> ReadMessages()
@@ -44,7 +46,7 @@ namespace Mail2Bug.Email.EWS
             return items
                 .Where(item => item is EmailMessage)
                 .OrderBy(message => message.DateTimeReceived)
-                .Select(message => new EWSIncomingMessage(message as EmailMessage))
+                .Select(message => new EWSIncomingMessage(message as EmailMessage, this._useConversationGuidOnly))
                 .AsEnumerable();
         }
 

--- a/Mail2Bug/Email/MailboxManagerFactory.cs
+++ b/Mail2Bug/Email/MailboxManagerFactory.cs
@@ -37,7 +37,8 @@ namespace Mail2Bug.Email
                     return new FolderMailboxManager(
                         exchangeService.Service, 
                         emailSettings.IncomingFolder,
-                        postProcessor);
+                        postProcessor,
+                        emailSettings.UseConversationGuidOnly);
 
                 case Config.EmailSettings.MailboxServiceType.EWSByRecipients:
 


### PR DESCRIPTION
The UseConversationGuidOnly setting is not included in the sample configs and hence defaults to false. This results in the entire ConversationIndex of the message to be used as the key. However, this value can change at different points in the conversation, resulting in replies spawning new bugs. These changes enable it by default to and also fixes some bugs related to its use.

We don't want people with existing installations to turn this on as that would break links with existing bugs. A warning has been included in the sample config file to call this out.