### PR TITLE
Remove invisible html elements like head, style etc. from comments

### DIFF
--- a/Mail2Bug/Email/EmailBodyProcessingUtils.cs
+++ b/Mail2Bug/Email/EmailBodyProcessingUtils.cs
@@ -50,10 +50,18 @@ namespace Mail2Bug.Email
         {
             // First remove comments, since they may have nested tags in them, which throw off the tag stripper regex
             text = Regex.Replace(text, "<!--.*?-->", string.Empty, RegexOptions.Singleline);
+
+            // Remove invisible html elements
+            text = Regex.Replace(text, "<head>.*</head>", string.Empty, RegexOptions.Singleline);
+            text = Regex.Replace(text, "<title>.*</title>", string.Empty, RegexOptions.Singleline);
+            text = Regex.Replace(text, "<style>.*</style>", string.Empty, RegexOptions.Singleline);
+            text = Regex.Replace(text, "<script>.*</script>", string.Empty, RegexOptions.Singleline);
+
+            // Remove tags and translate unicode entities
             text = Regex.Replace(text, "<.*?>", string.Empty, RegexOptions.Singleline);
             text = Regex.Replace(text, @"&#(?<ordinal>\d+);", ResolveOridnalToChar); 
 
-           var sb = new StringBuilder(text.Trim());
+            var sb = new StringBuilder(text.Trim());
 
             // Now unescape chars
             sb.Replace("&quot;", "\"");


### PR DESCRIPTION
If the initial email on a thread had custom styles, Outlook will carry these forward onto replies. Because mail2bug strips out the wrapping HTML, this will result in these CSS rules appearing in comments as text. This change removes HTML elements that are expected to be invisible from the message while generating plain text comment.