### PR TITLE
Retain inline images for HTML and RTF body formats.

### DIFF
--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -217,7 +217,6 @@
 
       <!-- 'EmailSettings' - contains settings related to accessing the email account and processing individual emails -->
       <EmailSettings>
-
         <!-- 'ServiceType' - this value dictates how the email inbox is monitored and which emails will be picked up for
              processing.
              
@@ -297,6 +296,11 @@
         <AppendOnlyEmailTitleRegex>.*(bug|work item)\s*#*\s*(?&lt;id&gt;\d+)</AppendOnlyEmailTitleRegex>
         <AppendOnlyEmailBodyRegex>!!!(bug|work item)\s*#*\s*(?&lt;id&gt;\d+)</AppendOnlyEmailBodyRegex>
         <ExplicitOverridesRegex>###\s*(?&lt;fieldName&gt;[^:]*):\s*(?&lt;value&gt;.*)</ExplicitOverridesRegex>
+
+        <!-- Process images that were inline in the email as inlined images in the resulting ticket body.
+             To activate this functionality, the EmailBodyFieldName must also be specified.
+             If this element is omitted, the default value is true.-->
+        <ConvertInlineAttachments>true</ConvertInlineAttachments>
       </EmailSettings>
     </InstanceConfig>
   </Instances>

--- a/Documentation/FullyAnnotatedConfigReference.xml
+++ b/Documentation/FullyAnnotatedConfigReference.xml
@@ -106,7 +106,11 @@
                people/tools overwriting it with unrelated data. You should also consider not adding the field to the work
                item editing form (since no one should be editing it manually) -->
         <ConversationIndexFieldName>ConversationID</ConversationIndexFieldName>
-
+        <!-- For inlining of images to work, the EmailBodyFieldName must identify the TFS field
+             that the email body is populated to (this is because the field value must be read back after 
+             creation for reparsing of the image URLs).
+             Note: you should remove any mapping to this field in the DefaultFieldValues collection. -->
+        <EmailBodyFieldName>Description</EmailBodyFieldName>
         <!-- 'DefaultFieldValues' defines all the deafult values that should be assigned to the work item fields, one
              DefaultValueDefinition item per field.
              The important part is to include a default value for every mandatory field, otherwise work item creation will
@@ -119,13 +123,11 @@
         
                The default settings supports the following special values, prefixed by double hash-signs.
                - Subject - The email subject
-               - MessageBody - The body of the email message converted to plain text (i.e. if the body was HTML,
-                               it would be stripped to plain text)
+               - MessageBody - The body of the email message converted to plain text
                - MessageBodyWithSender - Similar to MessageBody, but with an added line at the bottom mentioning the
                  display name and email address of the sender. Useful to include indication of the person whose email
                  triggered the work item creation
-               - RawMessageBody - The raw body of the email - i.e. if it's an HTML message, this would be the full
-                 message HTML
+               - HtmlMessageBody - The HTML body of the email - i.e. RTF and plain-text messages are converted to HTML
                - Now - Current date time in general ("g") date time format (see 
                  https://msdn.microsoft.com/en-us/library/az4se3k1%28v=vs.110%29.aspx for date time format specification)
                - Today - Current date in short date format ("d")
@@ -133,10 +135,12 @@
                           this would resolve to the sender display name.
                - Location - In case the email is a meeting invite, the location of the meeting; empty string otherwise.
                - StartTime - In case the email is a meeting invite, the meeting start time; empty string otherwise.
-               - EndTime - In case the email is a meeting invite, the meeting end time; empty string otherwise.
-                    
+               - EndTime - In case the email is a meeting invite, the meeting end time; empty string otherwise.        
+               
+               Note: The "Iteration Path" field also recognizes the special value "@CurrentIteration".
+               
                The example below sets default for 5 fields - 4 of them with static default values, and the last
-               one (Description) set to the text of the email body
+               one (Description) set to the plain text version of the email body
                -->
           <DefaultValueDefinition Field="Assigned To" Value="Unassigned" />
           <DefaultValueDefinition Field="Severity" Value="1" />

--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -105,7 +105,7 @@ namespace Mail2Bug
 
         public class WorkItemSettings
         {
-            // C'tor for assignign defaults
+            // C'tor for assigning defaults
             public WorkItemSettings()
             {
                 OverrideChangedBy = true;
@@ -120,6 +120,7 @@ namespace Mail2Bug
             }
 
             public string ConversationIndexFieldName { get; set; }
+            public string EmailBodyFieldName { get; set; }
 
             public List<DefaultValueDefinition> DefaultFieldValues { get; set; }
             public List<MnemonicDefinition> Mnemonics { get; set; }
@@ -187,6 +188,11 @@ namespace Mail2Bug
 
         public class EmailSettings
         {
+            public EmailSettings()
+            {
+                ConvertInlineAttachments = true;
+            }
+
             public enum MailboxServiceType
             {
                 EWSByFolder,
@@ -262,6 +268,8 @@ namespace Mail2Bug
                     return GetEncryptionScope(UseMachineScopeEncryption);
                 }
             }
+
+            public bool ConvertInlineAttachments { get; set; }
 
             private string _replyTemplate;
         }

--- a/Mail2Bug/Email/EWS/EWSExtendedProperty.cs
+++ b/Mail2Bug/Email/EWS/EWSExtendedProperty.cs
@@ -11,6 +11,7 @@ namespace Mail2Bug.Email.EWS
     {
         private const int PidTagBodyIdentifier = 0x1000;
         private const int PidTagConversationIdIdentifier = 0x3013;
+        private const int PidTagNativeBodyIdentifier = 0x1016;
 
         // Extended property for PidTagBody, which is the message body converted to plain text format
         // See https://msdn.microsoft.com/en-us/library/ee158918%28EXCHG.80%29.aspx
@@ -19,7 +20,14 @@ namespace Mail2Bug.Email.EWS
         // Extended property for PidTagConversationId, which is the GUID portion of the ConversationIndex
         // See https://msdn.microsoft.com/en-us/library/cc433490(v=EXCHG.80).aspx and
         // https://msdn.microsoft.com/en-us/library/ee204279(v=exchg.80).aspx for more information
-        public static readonly ExtendedPropertyDefinition PidTagConversationId = new ExtendedPropertyDefinition(PidTagConversationIdIdentifier, MapiPropertyType.Binary);
 
+        public static readonly ExtendedPropertyDefinition PidTagConversationId = new ExtendedPropertyDefinition(PidTagConversationIdIdentifier, MapiPropertyType.Binary);
+        // Extended property for PidTagNativeBody, which identifies what format the body is stored in (e.g. RTF, HTML)
+        // See https://msdn.microsoft.com/en-us/library/ee203274(EXCHG.80).aspx 
+        public static readonly ExtendedPropertyDefinition PidTagNativeBody = new ExtendedPropertyDefinition(PidTagNativeBodyIdentifier, MapiPropertyType.Integer);
+
+        // Value returned by PidTagNativeBody when body type is RTF-compressed
+        // See https://msdn.microsoft.com/en-us/library/ee218029(EXCHG.80).aspx
+        public const int PidTagNativeBodyRTFCompressed = 2;
     }
 }

--- a/Mail2Bug/Email/EWS/EWSIncomingAttachmentConverter.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingAttachmentConverter.cs
@@ -1,0 +1,134 @@
+﻿﻿using log4net;
+using Microsoft.Exchange.WebServices.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Mail2Bug.Email.EWS
+{
+    public class EWSIncomingAttachmentConverter
+    {
+        // TFS drops large base64 inline images: http://johannblais.blogspot.com/2015/08/migrate-tfs-repro-steps-field-to.html
+        private const int MaxBase64Length = 22 * 1024; // This a safe guess
+
+        private readonly EmailMessage _message;
+
+        private string _bodyText;
+        private List<IIncomingEmailAttachment> _attachments = null;
+
+        public EWSIncomingAttachmentConverter(EmailMessage message)
+        {
+            _message = message;
+        }
+
+        public void ProcessAttachments(bool convertInlineAttachments = false)
+        {
+            _bodyText = _message.Body.Text ?? String.Empty;
+            _attachments = new List<IIncomingEmailAttachment>();
+
+            bool doInlining = !String.IsNullOrEmpty(_bodyText) && convertInlineAttachments;
+
+            foreach (var ma in _message.Attachments)
+            {
+                if (doInlining)
+                    ma.Load(); // Content property requires load, and for RTF the ContentType property is also not available unless loaded
+
+                if (ma is FileAttachment)
+                    _attachments.Add(new EWSIncomingFileAttachment(ma as FileAttachment));
+                else if (ma is ItemAttachment)
+                    _attachments.Add(new EWSIncomingItemAttachment(ma as ItemAttachment));
+                else
+                    Logger.ErrorFormat("Skipping attachment because it's not a file attachment ({0})", ma.Name);
+            }
+
+            if (doInlining)
+            {
+                // RTF-email attachments have no ContentId value set. The only way to match them is by position.
+                // We want a uniform way to match attachments to content id references, so here we assign
+                // the applicable content id to each inline attachment by traversing the HTML for
+                // "cid:" references and positionally matching to the attachments.
+                // More info: https://blogs.msdn.microsoft.com/webdav_101/2016/06/21/ews-and-inline-attachments/
+                if (IsNativeRtfBody(_message))
+                    FixupContentIds();
+
+                // Use base64 when possible because these images will display inside Visual Studio from 
+                // hosted VSTS (visualstudio.com).
+                Base64EncodeImages();
+            }
+        }
+
+        public string BodyText { get { return _bodyText; } }
+
+        public IEnumerable<IIncomingEmailAttachment> Attachments { get { return _attachments; } }
+
+        private void FixupContentIds()
+        {
+            const string pattern = @"(\""cid:)(.*)(\"")";
+
+            var inlineAttachments = _attachments.Where(x => x.IsInline);
+
+            int index = 0;
+
+            _bodyText = Regex.Replace(_bodyText, pattern, match =>
+            {
+                var inlineAttachment = inlineAttachments.ElementAtOrDefault(index++);
+                if (inlineAttachments != null)
+                {
+                    var fileAttachment = inlineAttachment as EWSIncomingFileAttachment;
+                    if (fileAttachment != null)
+                    {
+                        Logger.DebugFormat("Fixing content id");
+                        string contentId = Guid.NewGuid().ToString();
+                        fileAttachment.SetContentId(contentId);
+                        return $"{match.Groups[1]}{contentId}{match.Groups[3]}";
+                    }
+                }
+                return match.Groups[0].ToString();
+            });
+        }
+
+        private void Base64EncodeImages()
+        {
+            const string pattern = @"(\<img.* src=\"")(cid:)(.*)(\"".*\>)";
+
+            var inlineAttachments = _attachments.OfType<EWSIncomingFileAttachment>().Where(x => x.IsInline);
+
+            _bodyText = Regex.Replace(_bodyText, pattern, match =>
+            {
+                string contentId = match.Groups[3].ToString();
+
+                var attachment = inlineAttachments.FirstOrDefault(x => x.ContentId == contentId);
+
+                if (attachment != null)
+                {
+                    string contentType = attachment.ContentType.ToLower();
+                    string base64 = Convert.ToBase64String(attachment.Content);
+
+                    if (base64.Length < MaxBase64Length)
+                    {
+                        Logger.DebugFormat("Inlining image attachment via base64 encoding");
+                        _attachments.Remove(attachment);
+                        return $"{match.Groups[1]}data:{contentType};base64,{base64}{match.Groups[4]}";
+                    }
+                }
+                return match.Groups[0].ToString();
+            });
+        }
+
+        private static bool IsNativeRtfBody(EmailMessage message)
+        {
+            int nativeBodyResult = 0;
+
+            if (message.TryGetProperty(EWSExtendedProperty.PidTagNativeBody, out nativeBodyResult))
+            {
+                return nativeBodyResult == EWSExtendedProperty.PidTagNativeBodyRTFCompressed;
+            }
+
+            // Optionally, in case native body property is not available, we could attempt to infer from ContentId in attachments.
+            return false;
+        }
+
+        private static readonly ILog Logger = LogManager.GetLogger(typeof(EWSIncomingAttachmentConverter));
+    }
+}

--- a/Mail2Bug/Email/EWS/EWSIncomingFileAttachment.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingFileAttachment.cs
@@ -7,10 +7,22 @@ namespace Mail2Bug.Email.EWS
     class EWSIncomingFileAttachment : IIncomingEmailAttachment
     {
         private readonly Microsoft.Exchange.WebServices.Data.FileAttachment _attachment;
+        private string _contentId;
 
         public EWSIncomingFileAttachment(Microsoft.Exchange.WebServices.Data.FileAttachment attachment)
         {
             _attachment = attachment;
+            _contentId = attachment.ContentId;
+        }
+
+        public bool IsInline { get { return _attachment.IsInline; } }
+        public string ContentId { get { return _contentId; } }
+        public string ContentType { get { return _attachment.ContentType; } }
+        public byte[] Content { get { return _attachment.Content; } }
+
+        public void SetContentId(string contentId)
+        {
+            _contentId = contentId;
         }
 
         public string SaveAttachmentToFile()

--- a/Mail2Bug/Email/EWS/EWSIncomingItemAttachment.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingItemAttachment.cs
@@ -19,6 +19,9 @@ namespace Mail2Bug.Email.EWS
             Logger.DebugFormat("Attachment name is {0}", _attachment.Name);
         }
 
+        public bool IsInline { get { return _attachment.IsInline; } }
+        public string ContentId { get { return _attachment.ContentId; } }
+
         public string SaveAttachmentToFile()
         {
             return SaveAttachmentToFile(FileUtils.GetValidFileName(_attachment.Name, "eml", Path.GetTempPath()));

--- a/Mail2Bug/Email/IIncomingEmailAttachment.cs
+++ b/Mail2Bug/Email/IIncomingEmailAttachment.cs
@@ -5,6 +5,8 @@
     /// </summary>
     public interface IIncomingEmailAttachment
     {
+        bool IsInline { get; }
+        string ContentId { get; }
         string SaveAttachmentToFile();
         string SaveAttachmentToFile(string filename);
     }

--- a/Mail2Bug/Email/IIncomingEmailMessage.cs
+++ b/Mail2Bug/Email/IIncomingEmailMessage.cs
@@ -13,7 +13,7 @@ namespace Mail2Bug.Email
     public interface IIncomingEmailMessage
     {
         string Subject { get; }
-        string RawBody { get; }
+        string HtmlBody { get; }
         string PlainTextBody { get; }
         string ConversationId { get; }
         string ConversationTopic { get; }
@@ -27,8 +27,6 @@ namespace Mail2Bug.Email
         IEnumerable<string> CcNames { get; }
         DateTime SentOn { get; }
         DateTime ReceivedOn { get; }
-
-        bool IsHtmlBody { get; }
 
         string Location { get; }
         DateTime? StartTime { get; }

--- a/Mail2Bug/Mail2Bug.csproj
+++ b/Mail2Bug/Mail2Bug.csproj
@@ -291,6 +291,7 @@
     <Compile Include="Email\EWS\ArchiverMessagePostProcessor.cs" />
     <Compile Include="Email\EWS\EWSConnectionManger.cs" />
     <Compile Include="Email\EWS\EWSExtendedProperty.cs" />
+    <Compile Include="Email\EWS\EWSIncomingAttachmentConverter.cs" />
     <Compile Include="Email\EWS\EWSIncomingFileAttachment.cs" />
     <Compile Include="Email\EWS\EWSIncomingItemAttachment.cs" />
     <Compile Include="Email\EWS\EWSIncomingMessage.cs" />

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -59,7 +59,7 @@ namespace Mail2Bug.MessageProcessingStrategies
                 // Since the work item *has* been created, failures in this stage are not treated as critical
                 var overrides = new OverridesExtractor(_config).GetOverrides(message);
                 TryApplyFieldOverrides(overrides, workItemId);
-                ProcessAttachments(message, workItemId);
+                ProcessAttachments(message, workItemId, _config.EmailSettings.ConvertInlineAttachments);
                 
                 if (_config.WorkItemSettings.AttachOriginalMessage)
                 {
@@ -104,7 +104,17 @@ namespace Mail2Bug.MessageProcessingStrategies
     		{
     		    workItemUpdates[defaultFieldValue.Field] = resolver.Resolve(defaultFieldValue.Value);
     		}
-    	}
+
+            string emailBodyFieldName = _config.WorkItemSettings.EmailBodyFieldName;
+            if (!String.IsNullOrEmpty(emailBodyFieldName))
+            {
+                if (workItemUpdates.Keys.Contains(emailBodyFieldName))
+                {
+                    Logger.Warn($"Field {emailBodyFieldName} is defined for mapping in {nameof(_config.WorkItemSettings.EmailBodyFieldName)} for mapping. The DefaultValueDefinition entry will be ignored.");
+                }
+                workItemUpdates[emailBodyFieldName] = resolver.HtmlMessageBody;
+            }
+        }
 
         private void TryApplyFieldOverrides(Dictionary<string, string> overrides, int workItemId)
         {
@@ -151,7 +161,7 @@ namespace Mail2Bug.MessageProcessingStrategies
             // Construct the text to be appended
             _workItemManager.ModifyWorkItem(workItemId, message.GetLastMessageText(), workItemUpdates);
 
-            ProcessAttachments(message, workItemId);
+            ProcessAttachments(message, workItemId, false);
 
             if (_config.WorkItemSettings.AttachUpdateMessages)
             {
@@ -159,32 +169,32 @@ namespace Mail2Bug.MessageProcessingStrategies
             }
         }
 
-        private void ProcessAttachments(IIncomingEmailMessage message, int workItemId)
+        private void ProcessAttachments(IIncomingEmailMessage message, int workItemId, bool convertInlineAttachments)
         {
-            var attachmentFiles = SaveAttachments(message);
-            _workItemManager.AttachFiles(workItemId, (from object file in attachmentFiles select file.ToString()).ToList());
-            attachmentFiles.Delete();
+            var fileList = SaveAttachments(message);
+            _workItemManager.AttachAndInlineFiles(workItemId, fileList);
+            fileList.ToList().ForEach(x => File.Delete(x.Item1));
         }
 
         /// <summary>
         /// Take attachments from the current mail message and put them in a work item
         /// </summary>
         /// <param name="message"></param>
-        private static TempFileCollection SaveAttachments(IIncomingEmailMessage message)
+        private static IEnumerable<Tuple<string, IIncomingEmailAttachment>> SaveAttachments(IIncomingEmailMessage message)
         {
-            var attachmentFiles = new TempFileCollection();
+            var attachedFiles = new List<Tuple<string, IIncomingEmailAttachment>>();
 
             foreach (var attachment in message.Attachments)
             {
-                var filename = attachment.SaveAttachmentToFile();
-                if (filename != null)
+                var file = attachment.SaveAttachmentToFile();
+                if (file != null)
                 {
-                    attachmentFiles.AddFile(filename, false);
-                    Logger.InfoFormat("Attachment saved to file {0}", filename);
+                    attachedFiles.Add(new Tuple<string, IIncomingEmailAttachment>(file, attachment));
+                    Logger.InfoFormat("Attachment saved to file {0}", file);
                 }
             }
 
-            return attachmentFiles;
+            return attachedFiles;
         }
 
         private static readonly ILog Logger = LogManager.GetLogger(typeof(SimpleBugStrategy));

--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -16,6 +16,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public const string MessageBodyKeyword = "##MessageBody";
         public const string MessageBodyWithSenderKeyword = "##MessageBodyWithSender";
         public const string RawMessageBodyKeyword = "##RawMessageBody";
+        public const string HtmlMessageBodyKeyword = "##HtmlMessageBody";
         public const string NowKeyword = "##Now";
         public const string TodayKeyword = "##Today";
         public const string LocationKeyword = "##Location";
@@ -36,7 +37,8 @@ namespace Mail2Bug.MessageProcessingStrategies
                 _valueResolutionMap[MessageBodyKeyword], 
                 message.SenderName, 
                 message.SenderAddress);
-            _valueResolutionMap[RawMessageBodyKeyword] = TextUtils.FixLineBreaks(message.RawBody);
+            _valueResolutionMap[RawMessageBodyKeyword] = message.HtmlBody; // Obsolete; left in for backwards compatibility
+            _valueResolutionMap[HtmlMessageBodyKeyword] = message.HtmlBody;
             _valueResolutionMap[NowKeyword] = DateTime.Now.ToString("g");
             _valueResolutionMap[TodayKeyword] = DateTime.Now.ToString("d");
             _valueResolutionMap[LocationKeyword] = message.Location;
@@ -55,7 +57,7 @@ namespace Mail2Bug.MessageProcessingStrategies
                 return value;
             }
 
-            // Found specia value - return resolution
+            // Found special value - return resolution
             var resolvedValue = _valueResolutionMap[value];
             Logger.DebugFormat("Resolved value '{0}' to '{1}'", value, resolvedValue);
             return resolvedValue;
@@ -65,7 +67,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public string Subject { get { return _valueResolutionMap[SubjectKeyword]; } }
         public string Sender { get { return _valueResolutionMap[SenderKeyword]; } }
         public string MessageBody { get { return _valueResolutionMap[MessageBodyKeyword]; } }
-        public string RawMessageBody { get { return _valueResolutionMap[RawMessageBodyKeyword]; } }
+        public string HtmlMessageBody { get { return _valueResolutionMap[HtmlMessageBodyKeyword]; } }
         public string Location { get { return _valueResolutionMap[LocationKeyword]; } }
         public string StartTime { get { return _valueResolutionMap[StartTimeKeyword]; } }
         public string EndTime { get { return _valueResolutionMap[EndTimeKeyword]; } }

--- a/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
@@ -1,11 +1,15 @@
+using System;
 using System.Collections.Generic;
+using Mail2Bug.Email;
 using Mail2Bug.MessageProcessingStrategies;
 
 namespace Mail2Bug.WorkItemManagement
 {
     public interface IWorkItemManager
     {
-        void AttachFiles(int workItemId, List<string> fileList);
+        void AttachFiles(int workItemId, IEnumerable<string> fileList);
+
+        void AttachAndInlineFiles(int workItemId, IEnumerable<Tuple<string, IIncomingEmailAttachment>> fileList);
 
         SortedList<string, int> WorkItemsCache { get; }
 

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -297,6 +297,11 @@ namespace Mail2Bug.WorkItemManagement
 
                 const string pattern = @"(\<img.* src=\"")(cid:)(.*)(\"".*\>)";
 
+                // Images that are too large to have been base64 encoded are handled here. The item body is scanned for content ids
+                // and matched up to their attachments, and the image src attribute is updated to point to the attachment.
+                // The attachment is then removed, since TFS appears to retail the file in the host system without needing to retain
+                // the attached reference.
+
                 html = Regex.Replace(html, pattern, match =>
                 {
                     string contentId = match.Groups[3].ToString();
@@ -472,33 +477,6 @@ namespace Mail2Bug.WorkItemManagement
             }
 
             workItem.Save();
-        }
-
-        private IEnumerable<int> InternalAttachFiles(int workItemId, IEnumerable<string> fileList)
-        {
-            var attachmentIndexes = new List<int>();
-
-            if (workItemId > 0)
-            {
-                try
-                {
-                    var workItem = _tfsStore.GetWorkItem(workItemId);
-                    workItem.Open();
-
-                    foreach (var file in fileList)
-                    {
-                        attachmentIndexes.Add(workItem.Attachments.Add(new Attachment(file)));
-                    }
-
-                    ValidateAndSaveWorkItem(workItem);
-                }
-                catch (Exception exception)
-                {
-                    Logger.Error(exception.ToString());
-                }
-            }
-
-            return attachmentIndexes;
         }
 
         private NameResolver InitNameResolver()

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -12,6 +12,8 @@ using Mail2Bug.MessageProcessingStrategies;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.TeamFoundation.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using System.Text.RegularExpressions;
+using Mail2Bug.Email;
 
 namespace Mail2Bug.WorkItemManagement
 {
@@ -39,7 +41,7 @@ namespace Mail2Bug.WorkItemManagement
                 throw new Exception("Cannot initialize TFS Store");
             }
 
-            Logger.InfoFormat("Geting TFS Project");
+            Logger.InfoFormat("Getting TFS Project");
             _tfsProject = _tfsStore.Projects[config.TfsServerConfig.Project];
 
 
@@ -242,7 +244,7 @@ namespace Mail2Bug.WorkItemManagement
                 _config.TfsServerConfig.ServiceIdentityPatKeyVaultSecret);
         }
 
-        public void AttachFiles(int workItemId, List<string> fileList)
+        public void AttachFiles(int workItemId, IEnumerable<string> fileList)
         {
             if (workItemId <= 0) return;
 
@@ -251,7 +253,66 @@ namespace Mail2Bug.WorkItemManagement
                 WorkItem workItem = _tfsStore.GetWorkItem(workItemId);
                 workItem.Open();
 
-                fileList.ForEach(file => workItem.Attachments.Add(new Attachment(file)));
+                foreach (var file in fileList)
+                    workItem.Attachments.Add(new Attachment(file));
+
+                ValidateAndSaveWorkItem(workItem);
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception.ToString());
+            }
+        }
+
+        public void AttachAndInlineFiles(int workItemId, IEnumerable<Tuple<string, IIncomingEmailAttachment>> fileList)
+        {
+            if (workItemId <= 0) return;
+
+            string fieldNameToUpdate = _config.WorkItemSettings.EmailBodyFieldName;
+
+            if (_config.EmailSettings.ConvertInlineAttachments && String.IsNullOrEmpty(fieldNameToUpdate))
+            {
+                Logger.WarnFormat("Inlining of images as attachments is not available because EmailBodyFieldName has not been set");
+                AttachFiles(workItemId, fileList.Select(f => f.Item1));
+                return;
+            }
+
+            try
+            {
+                var workItem = _tfsStore.GetWorkItem(workItemId);
+                workItem.PartialOpen();
+
+                var attachmentTrackers = fileList.Select(f => new
+                {
+                    WorkItemAttachmentIndex = workItem.Attachments.Add(new Attachment(f.Item1)),
+                    IsInline = f.Item2.IsInline,
+                    ContentId = f.Item2.ContentId
+                });
+
+                ValidateAndSaveWorkItem(workItem); // Save before proceeding to generate the URIs for the attachments
+
+                workItem.PartialOpen();
+
+                string html = workItem.Fields[fieldNameToUpdate].Value?.ToString();
+
+                const string pattern = @"(\<img.* src=\"")(cid:)(.*)(\"".*\>)";
+
+                html = Regex.Replace(html, pattern, match =>
+                {
+                    string contentId = match.Groups[3].ToString();
+
+                    var tracker = attachmentTrackers.FirstOrDefault(a => a.ContentId == contentId);
+                    if (tracker != null)
+                    {
+                        Logger.DebugFormat("Converting attached image to inline reference");
+                        var workItemAttachment = workItem.Attachments[tracker.WorkItemAttachmentIndex];
+                        workItem.Attachments.Remove(workItemAttachment); // No need to keep the image as an attachment once it's been inlined.
+                        return $"{match.Groups[1]}{workItemAttachment.Uri.ToString()}{match.Groups[4]}";
+                    }
+                    return match.Groups[0].ToString();
+                });
+
+                workItem.Fields[fieldNameToUpdate].Value = html;
                 ValidateAndSaveWorkItem(workItem);
             }
             catch (Exception exception)
@@ -411,6 +472,33 @@ namespace Mail2Bug.WorkItemManagement
             }
 
             workItem.Save();
+        }
+
+        private IEnumerable<int> InternalAttachFiles(int workItemId, IEnumerable<string> fileList)
+        {
+            var attachmentIndexes = new List<int>();
+
+            if (workItemId > 0)
+            {
+                try
+                {
+                    var workItem = _tfsStore.GetWorkItem(workItemId);
+                    workItem.Open();
+
+                    foreach (var file in fileList)
+                    {
+                        attachmentIndexes.Add(workItem.Attachments.Add(new Attachment(file)));
+                    }
+
+                    ValidateAndSaveWorkItem(workItem);
+                }
+                catch (Exception exception)
+                {
+                    Logger.Error(exception.ToString());
+                }
+            }
+
+            return attachmentIndexes;
         }
 
         private NameResolver InitNameResolver()

--- a/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
+++ b/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
@@ -5,10 +5,11 @@ using System.IO;
 using System.Linq;
 using log4net;
 using Mail2Bug.MessageProcessingStrategies;
+using Mail2Bug.Email;
 
 namespace Mail2Bug.WorkItemManagement
 {
-    public class WorkItemManagerMock :IWorkItemManager
+    public class WorkItemManagerMock : IWorkItemManager
     {
         private readonly string _keyField;
 
@@ -20,7 +21,7 @@ namespace Mail2Bug.WorkItemManagement
             WorkItemsCache = new SortedList<string, int>();
         }
 
-        public void AttachFiles(int workItemId, List<string> fileList)
+        public void AttachFiles(int workItemId, IEnumerable<string> fileList)
         {
             foreach (var filename in fileList.Where(filename => !File.Exists(filename)))
             {
@@ -38,6 +39,11 @@ namespace Mail2Bug.WorkItemManagement
             }
 
             Attachments[workItemId].AddRange(fileList);
+        }
+
+        void IWorkItemManager.AttachAndInlineFiles(int workItemId, IEnumerable<Tuple<string, IIncomingEmailAttachment>> fileList)
+        {
+            throw new NotImplementedException();
         }
 
         public void CacheWorkItem(int workItemId)

--- a/Mail2BugUnitTests/Mail2BugUnitTests.csproj
+++ b/Mail2BugUnitTests/Mail2BugUnitTests.csproj
@@ -82,7 +82,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="RegressionMessages\Basic.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Mail2BugUnitTests/Mocks/Email/IncomingAttachmentMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingAttachmentMock.cs
@@ -17,6 +17,10 @@ namespace Mail2BugUnitTests.Mocks.Email
             Rand.NextBytes(Data);
         }
 
+        public bool IsInline { get { return false; } }
+
+        public string ContentId { get { return String.Empty; } }
+
         public string SaveAttachmentToFile()
         {
             return SaveAttachmentToFile(Path.GetTempFileName());

--- a/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
@@ -35,7 +35,7 @@ namespace Mail2BugUnitTests.Mocks.Email
             var mock = new IncomingEmailMessageMock
                 {
                     Subject = RandomDataHelper.GetSubject(_seed++),
-                    RawBody = RandomDataHelper.GetBody(_seed++),
+                    HtmlBody = RandomDataHelper.GetBody(_seed++),
                     PlainTextBody = RandomDataHelper.GetBody(_seed++),
                     ConversationId = RandomDataHelper.GetConversationId(_seed++),
                     ConversationTopic = RandomDataHelper.GetSubject(_seed++),
@@ -63,7 +63,7 @@ namespace Mail2BugUnitTests.Mocks.Email
         }
 
         public string Subject { get; set; }
-        public string RawBody { get; set; }
+        public string HtmlBody { get; set; }
         public string PlainTextBody { get; set; }
         public string ConversationId { get; set; }
         public string ConversationTopic { get; set; }
@@ -97,7 +97,7 @@ namespace Mail2BugUnitTests.Mocks.Email
             {
                 sw.WriteLine("Subject: " + Subject);
                 sw.WriteLine();
-                sw.WriteLine(RawBody);
+                sw.WriteLine(HtmlBody);
             }
 
             return filename;

--- a/Mail2BugUnitTests/Mocks/Email/MailManagerMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/MailManagerMock.cs
@@ -47,7 +47,7 @@ namespace Mail2BugUnitTests.Mocks.Email
             var message = AddMessage(false);
             message.Subject = subject;
             message.PlainTextBody = body;
-            message.RawBody = body;
+            message.HtmlBody = body;
 
             return message;
         }


### PR DESCRIPTION
I had held off on this because I wasn't entirely happy with the clarity of the changes. But I received a private request for this enhancement a few days ago, so I thought it best to go ahead. I have applied the needed changes to the latest from master. Please let me know if you recommend any improvements.

It needs the element `<EmailBodyFieldName>` defined to activate it. It works for both HTML and RTF body emails, and it will base64 inline smaller images, otherwise retain the image attachment and reference it. 

I also changed the field RawMessageBody to HtmlMessageBody to because it will always contain HTML rather than the raw format (since pull request #57). For backwards compatibility, RawMessageBody is still honored internally.

This resolves issue #23.