### PR TITLE
Use a different URL for workitems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ ipch/
 TestResults/
 Ankh.NoLoad
 pingme.txt
+*.userprefs
 
  
 

--- a/Documentation/ReplyTemplateExample.htm
+++ b/Documentation/ReplyTemplateExample.htm
@@ -22,8 +22,8 @@
 
                 <div class="subtitle">[TFSProject] &middot; [TFSWorkItemTemplate]</div>
 
-                <h1><a href="[TFSCollectionUri]/[TFSProject]/_workitems#_a=edit&amp;id=[_ID]">[_ID]</a></h1>
-                <h2><a href="[TFSCollectionUri]/[TFSProject]/_workitems#_a=edit&amp;id=[_ID]">[_TITLE]</a></h2>
+                <h1><a href="[TFSCollectionUri]/[TFSProject]/_workitems?_a=edit&amp;id=[_ID]">[_ID]</a></h1>
+                <h2><a href="[TFSCollectionUri]/[TFSProject]/_workitems?_a=edit&amp;id=[_ID]">[_TITLE]</a></h2>
                 <h3>[_OWNER:Unassigned]</h3>
 
                 <!--

--- a/Documentation/ReplyTemplateExample.htm
+++ b/Documentation/ReplyTemplateExample.htm
@@ -22,8 +22,8 @@
 
                 <div class="subtitle">[TFSProject] &middot; [TFSWorkItemTemplate]</div>
 
-                <h1><a href="[TFSCollectionUri]/[TFSProject]/_workitems?_a=edit&amp;id=[_ID]">[_ID]</a></h1>
-                <h2><a href="[TFSCollectionUri]/[TFSProject]/_workitems?_a=edit&amp;id=[_ID]">[_TITLE]</a></h2>
+                <h1><a href="[TFSCollectionUri]/[TFSProject]/_workitems/edit/[_ID]">[_ID]</a></h1>
+                <h2><a href="[TFSCollectionUri]/[TFSProject]/_workitems/edit/[_ID]">[_TITLE]</a></h2>
                 <h3>[_OWNER:Unassigned]</h3>
 
                 <!--


### PR DESCRIPTION
The sample config has a bug URL of the format `_workitems#_a=edit&id=[_ID]` and it works fine for the most parts. However, if the user is not already logged in, the bit after the `#` is lost after the login flow and the user ends up in the queries tab instead of the specific bug. 

The URL `_workitems?_a=edit&id=[_ID]` works fine on VSTS but is not recognized in TFS 2013; `_workitems/edit/[_ID]` works in both.
