### PR TITLE
Stricter match when using UseConversationGuidOnly

### DIFF
--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -26,9 +26,10 @@ namespace Mail2Bug.MessageProcessingStrategies
 		    _ackEmailHandler = new AckEmailHandler(config);
             _messageToWorkItemMapper = 
                 new MessageToWorkItemMapper(
-                    _config.EmailSettings.AppendOnlyEmailTitleRegex, 
+                    _config.EmailSettings.AppendOnlyEmailTitleRegex,
                     _config.EmailSettings.AppendOnlyEmailBodyRegex,
-                    _workItemManager.WorkItemsCache);
+                    _workItemManager.WorkItemsCache,
+                    _config.EmailSettings.UseConversationGuidOnly);
         }
 
         public void ProcessInboxMessage(IIncomingEmailMessage message)


### PR DESCRIPTION
Mail2Bug does a StartsWith match to locate bugs based on the conversation ID, since the conversation IDs of two emails are not identical. However, when UseConversationGuidOnly is enabled, the IDs are of fixed length and we can do an equality match. This will also protect, to some degree, against false matches with inadvertent, manually entered values in the field.