### PR TITLE
Feature/email address specialvalue

### DIFF
--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -21,6 +21,8 @@ namespace Mail2Bug.MessageProcessingStrategies
         public const string LocationKeyword = "##Location";
         public const string StartTimeKeyword = "##StartTime";
         public const string EndTimeKeyword = "##EndTime";
+        public const string SenderEmailKeyword = "##SenderEmail";
+
 
         #endregion
 
@@ -42,6 +44,7 @@ namespace Mail2Bug.MessageProcessingStrategies
             _valueResolutionMap[LocationKeyword] = message.Location;
             _valueResolutionMap[StartTimeKeyword] = GetValidTimeString(message.StartTime);
             _valueResolutionMap[EndTimeKeyword] = GetValidTimeString(message.EndTime);
+            _valueResolutionMap[SenderEmailKeyword] = message.SenderAddress;
         }
 
 
@@ -69,6 +72,7 @@ namespace Mail2Bug.MessageProcessingStrategies
         public string Location { get { return _valueResolutionMap[LocationKeyword]; } }
         public string StartTime { get { return _valueResolutionMap[StartTimeKeyword]; } }
         public string EndTime { get { return _valueResolutionMap[EndTimeKeyword]; } }
+        public string SenderEmail { get { return _valueResolutionMap[SenderEmailKeyword]; } }
 
         private string GetSender(IIncomingEmailMessage message)
         {

--- a/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SpecialValueResolver.cs
@@ -23,7 +23,6 @@ namespace Mail2Bug.MessageProcessingStrategies
         public const string EndTimeKeyword = "##EndTime";
         public const string SenderEmailKeyword = "##SenderEmail";
 
-
         #endregion
 
         public SpecialValueResolver(IIncomingEmailMessage message, INameResolver resolver)


### PR DESCRIPTION
## What
Adding Special value for showing only sender email address. 

## Why
Some of teams would like to have email address in their work item field. Currently ##MessageBodyWithSenderKeyword contains email address but it exists along with email body, there is no Special value that contains only email address that can be handy.

