### PR TITLE
Support HTML comments & embedded images

### DIFF
--- a/Mail2Bug/Config.cs
+++ b/Mail2Bug/Config.cs
@@ -130,6 +130,7 @@ namespace Mail2Bug
             public bool ApplyOverridesDuringUpdate { get; set; }
             public bool AttachOriginalMessage { get; set; }
             public bool AttachUpdateMessages { get; set; }
+            public bool EnableExperimentalHtmlFeatures { get; set; }
 
             public ProcessingStrategyType ProcessingStrategy = ProcessingStrategyType.SimpleBugStrategy;
         }

--- a/Mail2Bug/Email/EWS/EWSIncomingFileAttachment.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingFileAttachment.cs
@@ -28,6 +28,12 @@ namespace Mail2Bug.Email.EWS
             return filename;
         }
 
+        public string ContentId
+        {
+            get => _attachment.ContentId;
+            set => _attachment.ContentId = value;
+        }
+
         private static readonly ILog Logger = LogManager.GetLogger(typeof(EWSIncomingFileAttachment));
     }
 }

--- a/Mail2Bug/Email/EWS/EWSIncomingItemAttachment.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingItemAttachment.cs
@@ -38,6 +38,12 @@ namespace Mail2Bug.Email.EWS
             return filename;
         }
 
+        public string ContentId
+        {
+            get => _attachment.ContentId;
+            set => _attachment.ContentId = value;
+        }
+
         private static readonly ILog Logger = LogManager.GetLogger(typeof (EWSIncomingItemAttachment));
     }
 }

--- a/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
+++ b/Mail2Bug/Email/EWS/EWSIncomingMessage.cs
@@ -116,9 +116,9 @@ namespace Mail2Bug.Email.EWS
             return filename;
         }
 
-        public string GetLastMessageText()
+        public string GetLastMessageText(bool enableExperimentalHtmlFeatures)
         {
-            return EmailBodyProcessingUtils.GetLastMessageText(this);
+            return EmailBodyProcessingUtils.GetLastMessageText(this, enableExperimentalHtmlFeatures);
         }
 
         public void Delete()

--- a/Mail2Bug/Email/EmailBodyProcessingUtils.cs
+++ b/Mail2Bug/Email/EmailBodyProcessingUtils.cs
@@ -11,9 +11,9 @@ namespace Mail2Bug.Email
 {
     public class EmailBodyProcessingUtils
     {
-        public static string GetLastMessageText(IIncomingEmailMessage message)
+        public static string GetLastMessageText(IIncomingEmailMessage message, bool enableExperimentalHtmlFeatures)
         {
-            return message.IsHtmlBody ? GetLastMessageText_Html(message.RawBody) : GetLastMessageText_PlainText(message);
+            return enableExperimentalHtmlFeatures && message.IsHtmlBody ? GetLastMessageText_Html(message.RawBody) : GetLastMessageText_PlainText(message);
         }
 
         private static string GetLastMessageText_PlainText(IIncomingEmailMessage message)

--- a/Mail2Bug/Email/EmailBodyProcessingUtils.cs
+++ b/Mail2Bug/Email/EmailBodyProcessingUtils.cs
@@ -17,7 +17,7 @@ namespace Mail2Bug.Email
         private static string GetLastMessageText_PlainText(IIncomingEmailMessage message)
         {
             var lastMessage = new StringBuilder();
-            lastMessage.Append(message.RawBody);
+            lastMessage.Append(message.PlainTextBody);
 
             var next = GetReplySeperatorIndex(lastMessage.ToString());
 

--- a/Mail2Bug/Email/IIncomingEmailAttachment.cs
+++ b/Mail2Bug/Email/IIncomingEmailAttachment.cs
@@ -7,5 +7,6 @@
     {
         string SaveAttachmentToFile();
         string SaveAttachmentToFile(string filename);
+        string ContentId { get; set; }
     }
 }

--- a/Mail2Bug/Email/IIncomingEmailMessage.cs
+++ b/Mail2Bug/Email/IIncomingEmailMessage.cs
@@ -43,7 +43,7 @@ namespace Mail2Bug.Email
         /// messages dropped, whereas the body includes all of that "history".
         /// </summary>
         /// <returns></returns>
-        string GetLastMessageText();
+        string GetLastMessageText(bool enableExperimentalHtmlFeatures);
 
         /// <summary>
         /// Deletes the message

--- a/Mail2Bug/Email/MessageAttachmentCollection.cs
+++ b/Mail2Bug/Email/MessageAttachmentCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.CodeDom.Compiler;
+﻿using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,7 +8,7 @@ namespace Mail2Bug.Email
     /// <summary>
     /// Collection of Exchange email attachments that have been downloaded locally
     /// </summary>
-    public class MessageAttachmentCollection
+    public class MessageAttachmentCollection : IDisposable
     {
         private readonly List<MessageAttachmentInfo> _attachments;
         private readonly TempFileCollection _tempFileCollection;
@@ -30,6 +31,11 @@ namespace Mail2Bug.Email
         public void DeleteLocalFiles()
         {
             _tempFileCollection.Delete();
+        }
+
+        public void Dispose()
+        {
+            DeleteLocalFiles();
         }
     }
 }

--- a/Mail2Bug/Email/MessageAttachmentCollection.cs
+++ b/Mail2Bug/Email/MessageAttachmentCollection.cs
@@ -1,0 +1,35 @@
+﻿using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mail2Bug.Email
+{
+    /// <summary>
+    /// Collection of Exchange email attachments that have been downloaded locally
+    /// </summary>
+    public class MessageAttachmentCollection
+    {
+        private readonly List<MessageAttachmentInfo> _attachments;
+        private readonly TempFileCollection _tempFileCollection;
+
+        public IReadOnlyCollection<MessageAttachmentInfo> Attachments => _attachments;
+        public IEnumerable<string> LocalFilePaths => _attachments.Select(a => a.FilePath);
+
+        public MessageAttachmentCollection()
+        {
+            _attachments = new List<MessageAttachmentInfo>();
+            _tempFileCollection = new TempFileCollection();
+        }
+
+        public void Add(string localFilePath, string contentId)
+        {
+            _attachments.Add(new MessageAttachmentInfo(localFilePath, contentId));
+            _tempFileCollection.AddFile(localFilePath, keepFile: false);
+        }
+
+        public void DeleteLocalFiles()
+        {
+            _tempFileCollection.Delete();
+        }
+    }
+}

--- a/Mail2Bug/Email/MessageAttachmentInfo.cs
+++ b/Mail2Bug/Email/MessageAttachmentInfo.cs
@@ -1,0 +1,18 @@
+﻿namespace Mail2Bug.Email
+{
+    /// <summary>
+    /// Represents basic information about an Exchange email attachment that has been downloaded locally and has a known exchange content id
+    /// </summary>
+    public class MessageAttachmentInfo
+    {
+        public MessageAttachmentInfo(string filePath, string contentId)
+        {
+            FilePath = filePath;
+            ContentId = contentId;
+        }
+
+        public string FilePath { get; }
+
+        public string ContentId { get; }
+    }
+}

--- a/Mail2Bug/Mail2Bug.csproj
+++ b/Mail2Bug/Mail2Bug.csproj
@@ -36,6 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CsQuery, Version=1.3.3.249, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CsQuery.1.3.4\lib\net40\CsQuery.dll</HintPath>
+    </Reference>
     <Reference Include="Hyak.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Hyak.Common.1.0.2\lib\net45\Hyak.Common.dll</HintPath>
       <Private>True</Private>

--- a/Mail2Bug/Mail2Bug.csproj
+++ b/Mail2Bug/Mail2Bug.csproj
@@ -323,6 +323,8 @@
     <Compile Include="MessageProcessingStrategies\DateBasedValueResolver.cs" />
     <Compile Include="MessageProcessingStrategies\IMessageProcessingStrategy.cs" />
     <Compile Include="MessageProcessingStrategies\INameResolver.cs" />
+    <Compile Include="Email\MessageAttachmentCollection.cs" />
+    <Compile Include="Email\MessageAttachmentInfo.cs" />
     <Compile Include="MessageProcessingStrategies\NameResolver.cs" />
     <Compile Include="MessageProcessingStrategies\NameResolverMock.cs" />
     <Compile Include="MessageProcessingStrategies\OverridesExtractor.cs" />

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using log4net;
@@ -49,9 +48,11 @@ namespace Mail2Bug.MessageProcessingStrategies
         {
             var workItemUpdates = new Dictionary<string, string>();
 
-            InitWorkItemFields(message, workItemUpdates);
+            var attachments = SaveAttachments(message);
 
-        	var workItemId = _workItemManager.CreateWorkItem(workItemUpdates);
+            InitWorkItemFields(message, workItemUpdates, attachments);
+
+        	var workItemId = _workItemManager.CreateWorkItem(workItemUpdates, attachments);
             Logger.InfoFormat("Added new work item {0} for message with subject: {1} (conversation index:{2})", 
                 workItemId, message.Subject, message.ConversationId);
 
@@ -60,12 +61,13 @@ namespace Mail2Bug.MessageProcessingStrategies
                 // Since the work item *has* been created, failures in this stage are not treated as critical
                 var overrides = new OverridesExtractor(_config).GetOverrides(message);
                 TryApplyFieldOverrides(overrides, workItemId);
-                ProcessAttachments(message, workItemId);
                 
                 if (_config.WorkItemSettings.AttachOriginalMessage)
                 {
                     AttachMessageToWorkItem(message, workItemId, "OriginalMessage");
                 }
+
+                attachments.DeleteLocalFiles();
             }
             catch (Exception ex)
             {
@@ -88,11 +90,11 @@ namespace Mail2Bug.MessageProcessingStrategies
                 // Remove the file once we're done attaching it
                 tfc.AddFile(filePath, false);
 
-                _workItemManager.AttachFiles(workItemId, new List<string> { filePath });
+                _workItemManager.AttachFiles(workItemId, new List<MessageAttachmentInfo> { new MessageAttachmentInfo(filePath, string.Empty) });
             }
         }
 
-        private void InitWorkItemFields(IIncomingEmailMessage message, Dictionary<string, string> workItemUpdates)
+        private void InitWorkItemFields(IIncomingEmailMessage message, Dictionary<string, string> workItemUpdates, MessageAttachmentCollection attachments)
     	{
             var resolver = new SpecialValueResolver(message, _workItemManager.GetNameResolver());
 
@@ -103,8 +105,14 @@ namespace Mail2Bug.MessageProcessingStrategies
 
     		foreach (var defaultFieldValue in _config.WorkItemSettings.DefaultFieldValues)
     		{
-    		    workItemUpdates[defaultFieldValue.Field] = resolver.Resolve(defaultFieldValue.Value);
-    		}
+    		    var result = resolver.Resolve(defaultFieldValue.Value);
+                if (message.IsHtmlBody && defaultFieldValue.Value == SpecialValueResolver.RawMessageBodyKeyword)
+                {
+                    result = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(result, attachments.Attachments);
+                }
+
+                workItemUpdates[defaultFieldValue.Field] = result;
+            }
     	}
 
         private void TryApplyFieldOverrides(Dictionary<string, string> overrides, int workItemId)
@@ -118,7 +126,7 @@ namespace Mail2Bug.MessageProcessingStrategies
             try
             {
                 Logger.DebugFormat("Overrides found. Calling 'ModifyWorkItem'");
-                _workItemManager.ModifyWorkItem(workItemId, "", false, overrides);
+                _workItemManager.ModifyWorkItem(workItemId, "", false, overrides, null);
             }
             catch (Exception ex)
             {
@@ -150,10 +158,12 @@ namespace Mail2Bug.MessageProcessingStrategies
                 overrides.ToList().ForEach(x => workItemUpdates[x.Key] = x.Value);
             }
 
-            // Construct the text to be appended
-            _workItemManager.ModifyWorkItem(workItemId, lastMessageText, message.IsHtmlBody, workItemUpdates);
+            var attachments = SaveAttachments(message);
 
-            ProcessAttachments(message, workItemId);
+            // Construct the text to be appended
+            _workItemManager.ModifyWorkItem(workItemId, lastMessageText, message.IsHtmlBody, workItemUpdates, attachments);
+
+            attachments.DeleteLocalFiles();
 
             if (_config.WorkItemSettings.AttachUpdateMessages)
             {
@@ -161,32 +171,24 @@ namespace Mail2Bug.MessageProcessingStrategies
             }
         }
 
-        private void ProcessAttachments(IIncomingEmailMessage message, int workItemId)
-        {
-            var attachmentFiles = SaveAttachments(message);
-            _workItemManager.AttachFiles(workItemId, (from object file in attachmentFiles select file.ToString()).ToList());
-            attachmentFiles.Delete();
-        }
-
         /// <summary>
         /// Take attachments from the current mail message and put them in a work item
         /// </summary>
         /// <param name="message"></param>
-        private static TempFileCollection SaveAttachments(IIncomingEmailMessage message)
+        private static MessageAttachmentCollection SaveAttachments(IIncomingEmailMessage message)
         {
-            var attachmentFiles = new TempFileCollection();
-
+            var result = new MessageAttachmentCollection();
             foreach (var attachment in message.Attachments)
             {
                 var filename = attachment.SaveAttachmentToFile();
                 if (filename != null)
                 {
-                    attachmentFiles.AddFile(filename, false);
+                    result.Add(filename, attachment.ContentId);
                     Logger.InfoFormat("Attachment saved to file {0}", filename);
                 }
             }
 
-            return attachmentFiles;
+            return result;
         }
 
         private static readonly ILog Logger = LogManager.GetLogger(typeof(SimpleBugStrategy));
@@ -195,5 +197,44 @@ namespace Mail2Bug.MessageProcessingStrategies
         {
             DisposeUtils.DisposeIfDisposable(_workItemManager);
         }
+    }
+
+    public class MessageAttachmentCollection
+    {
+        private readonly List<MessageAttachmentInfo> _attachments;
+        private readonly TempFileCollection _tempFileCollection;
+
+        public IReadOnlyCollection<MessageAttachmentInfo> Attachments => _attachments;
+        public IEnumerable<string> LocalFilePaths => _attachments.Select(a => a.FilePath);
+
+        public MessageAttachmentCollection()
+        {
+            _attachments = new List<MessageAttachmentInfo>();
+            _tempFileCollection = new TempFileCollection();
+        }
+
+        public void Add(string localFilePath, string contentId)
+        {
+            _attachments.Add(new MessageAttachmentInfo(localFilePath, contentId));
+            _tempFileCollection.AddFile(localFilePath, keepFile: false);
+        }
+
+        public void DeleteLocalFiles()
+        {
+            _tempFileCollection.Delete();
+        }
+    }
+
+    public class MessageAttachmentInfo
+    {
+        public MessageAttachmentInfo(string filePath, string contentId)
+        {
+            FilePath = filePath;
+            ContentId = contentId;
+        }
+
+        public string FilePath { get; }
+
+        public string ContentId { get; }
     }
 }

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -162,7 +162,8 @@ namespace Mail2Bug.MessageProcessingStrategies
             var attachments = SaveAttachments(message);
 
             // Construct the text to be appended
-            _workItemManager.ModifyWorkItem(workItemId, lastMessageText, message.IsHtmlBody, workItemUpdates, attachments);
+            bool commentIsHtml = message.IsHtmlBody && _config.WorkItemSettings.EnableExperimentalHtmlFeatures;
+            _workItemManager.ModifyWorkItem(workItemId, lastMessageText, commentIsHtml, workItemUpdates, attachments);
 
             attachments.DeleteLocalFiles();
 

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -103,10 +103,11 @@ namespace Mail2Bug.MessageProcessingStrategies
             workItemUpdates[_config.WorkItemSettings.ConversationIndexFieldName] = 
                 rawConversationIndex.Substring(0, Math.Min(rawConversationIndex.Length, TfsTextFieldMaxLength));
 
-    		foreach (var defaultFieldValue in _config.WorkItemSettings.DefaultFieldValues)
+            bool enableImgUpdating = _config.WorkItemSettings.EnableExperimentalHtmlFeatures;
+            foreach (var defaultFieldValue in _config.WorkItemSettings.DefaultFieldValues)
     		{
     		    var result = resolver.Resolve(defaultFieldValue.Value);
-                if (message.IsHtmlBody && defaultFieldValue.Value == SpecialValueResolver.RawMessageBodyKeyword)
+                if (enableImgUpdating && message.IsHtmlBody && defaultFieldValue.Value == SpecialValueResolver.RawMessageBodyKeyword)
                 {
                     result = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(result, attachments.Attachments);
                 }
@@ -147,7 +148,7 @@ namespace Mail2Bug.MessageProcessingStrategies
                 workItemUpdates["Changed By"] = resolver.Sender;
             }
 
-            string lastMessageText = message.GetLastMessageText();
+            string lastMessageText = message.GetLastMessageText(_config.WorkItemSettings.EnableExperimentalHtmlFeatures);
             if (_config.WorkItemSettings.ApplyOverridesDuringUpdate)
             {
                 var extractor = new OverridesExtractor(_config);

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -118,7 +118,7 @@ namespace Mail2Bug.MessageProcessingStrategies
             try
             {
                 Logger.DebugFormat("Overrides found. Calling 'ModifyWorkItem'");
-                _workItemManager.ModifyWorkItem(workItemId, "", overrides);
+                _workItemManager.ModifyWorkItem(workItemId, "", false, overrides);
             }
             catch (Exception ex)
             {
@@ -139,10 +139,11 @@ namespace Mail2Bug.MessageProcessingStrategies
                 workItemUpdates["Changed By"] = resolver.Sender;
             }
 
+            string lastMessageText = message.GetLastMessageText();
             if (_config.WorkItemSettings.ApplyOverridesDuringUpdate)
             {
                 var extractor = new OverridesExtractor(_config);
-                var overrides = extractor.GetOverrides(message.GetLastMessageText());
+                var overrides = extractor.GetOverrides(lastMessageText);
 
                 Logger.DebugFormat("Found {0} overrides for update message", overrides.Count);
 
@@ -150,7 +151,7 @@ namespace Mail2Bug.MessageProcessingStrategies
             }
 
             // Construct the text to be appended
-            _workItemManager.ModifyWorkItem(workItemId, message.GetLastMessageText(), workItemUpdates);
+            _workItemManager.ModifyWorkItem(workItemId, lastMessageText, message.IsHtmlBody, workItemUpdates);
 
             ProcessAttachments(message, workItemId);
 

--- a/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
+++ b/Mail2Bug/MessageProcessingStrategies/SimpleBugStrategy.cs
@@ -198,43 +198,4 @@ namespace Mail2Bug.MessageProcessingStrategies
             DisposeUtils.DisposeIfDisposable(_workItemManager);
         }
     }
-
-    public class MessageAttachmentCollection
-    {
-        private readonly List<MessageAttachmentInfo> _attachments;
-        private readonly TempFileCollection _tempFileCollection;
-
-        public IReadOnlyCollection<MessageAttachmentInfo> Attachments => _attachments;
-        public IEnumerable<string> LocalFilePaths => _attachments.Select(a => a.FilePath);
-
-        public MessageAttachmentCollection()
-        {
-            _attachments = new List<MessageAttachmentInfo>();
-            _tempFileCollection = new TempFileCollection();
-        }
-
-        public void Add(string localFilePath, string contentId)
-        {
-            _attachments.Add(new MessageAttachmentInfo(localFilePath, contentId));
-            _tempFileCollection.AddFile(localFilePath, keepFile: false);
-        }
-
-        public void DeleteLocalFiles()
-        {
-            _tempFileCollection.Delete();
-        }
-    }
-
-    public class MessageAttachmentInfo
-    {
-        public MessageAttachmentInfo(string filePath, string contentId)
-        {
-            FilePath = filePath;
-            ContentId = contentId;
-        }
-
-        public string FilePath { get; }
-
-        public string ContentId { get; }
-    }
 }

--- a/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
@@ -5,21 +5,24 @@ namespace Mail2Bug.WorkItemManagement
 {
     public interface IWorkItemManager
     {
-        void AttachFiles(int workItemId, List<string> fileList);
+        void AttachFiles(int workItemId, IReadOnlyCollection<MessageAttachmentInfo> fileList);
 
         SortedList<string, int> WorkItemsCache { get; }
 
         void CacheWorkItem(int workItemId);
 
         /// <param name="values">Field Values</param>
+        /// <param name="attachments"></param>
         /// <returns>Bug ID</returns>
-        int CreateWorkItem(Dictionary<string, string> values);
+        int CreateWorkItem(Dictionary<string, string> values, MessageAttachmentCollection attachments);
 
         /// <param name="workItemId">The ID of the bug to modify </param>
         /// <param name="comment">Comment to add to description</param>
         /// <param name="commentIsHtml"></param>
         /// <param name="values">List of fields to change</param>
-        void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values);
+        /// <param name="attachments"></param>
+        void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values,
+            MessageAttachmentCollection attachments);
 
         INameResolver GetNameResolver();
 

--- a/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
@@ -17,8 +17,9 @@ namespace Mail2Bug.WorkItemManagement
 
         /// <param name="workItemId">The ID of the bug to modify </param>
         /// <param name="comment">Comment to add to description</param>
+        /// <param name="commentIsHtml"></param>
         /// <param name="values">List of fields to change</param>
-        void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values);
+        void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values);
 
         INameResolver GetNameResolver();
 

--- a/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/IWorkItemManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Mail2Bug.Email;
 using Mail2Bug.MessageProcessingStrategies;
 
 namespace Mail2Bug.WorkItemManagement

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -326,7 +326,10 @@ namespace Mail2Bug.WorkItemManagement
 
             if (commentIsHtml)
             {
-                workItem.History = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(comment, attachments.Attachments);
+                if (_config.WorkItemSettings.EnableExperimentalHtmlFeatures)
+                {
+                    workItem.History = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(comment, attachments.Attachments);
+                }
             }
             else
             {

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -338,9 +338,12 @@ namespace Mail2Bug.WorkItemManagement
                 TryApplyFieldValue(workItem, key, values[key]);
             }
 
-            foreach (var attachment in attachments.Attachments)
+            if (attachments != null)
             {
-                workItem.Attachments.Add(new Attachment(attachment.FilePath));
+                foreach (var attachment in attachments.Attachments)
+                {
+                    workItem.Attachments.Add(new Attachment(attachment.FilePath));
+                }
             }
 
             ValidateAndSaveWorkItem(workItem);

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -326,10 +326,7 @@ namespace Mail2Bug.WorkItemManagement
 
             if (commentIsHtml)
             {
-                if (_config.WorkItemSettings.EnableExperimentalHtmlFeatures)
-                {
-                    workItem.History = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(comment, attachments.Attachments);
-                }
+                workItem.History = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(comment, attachments.Attachments);
             }
             else
             {

--- a/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
+++ b/Mail2Bug/WorkItemManagement/TFSWorkItemManager.cs
@@ -303,7 +303,7 @@ namespace Mail2Bug.WorkItemManagement
         /// <param name="workItemId">The ID of the work item to modify </param>
         /// <param name="comment">Comment to add to description</param>
         /// <param name="values">List of fields to change</param>
-        public void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values)
+        public void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values)
         {
             if (workItemId <= 0) return;
 
@@ -311,7 +311,7 @@ namespace Mail2Bug.WorkItemManagement
 
             workItem.Open();
 
-            workItem.History = comment.Replace("\n", "<br>");
+            workItem.History = commentIsHtml ? comment : comment.Replace("\n", "<br>");
             foreach (var key in values.Keys)
             {
                 TryApplyFieldValue(workItem, key, values[key]);

--- a/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
+++ b/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
@@ -20,9 +20,9 @@ namespace Mail2Bug.WorkItemManagement
             WorkItemsCache = new SortedList<string, int>();
         }
 
-        public void AttachFiles(int workItemId, List<string> fileList)
+        public void AttachFiles(int workItemId, IReadOnlyCollection<MessageAttachmentInfo> fileList)
         {
-            foreach (var filename in fileList.Where(filename => !File.Exists(filename)))
+            foreach (var filename in fileList.Where(filename => !File.Exists(filename.FilePath)))
             {
                 Logger.ErrorFormat("Couldn't find attachment file {0}", filename);
             }
@@ -37,7 +37,7 @@ namespace Mail2Bug.WorkItemManagement
                 Attachments[workItemId] = new List<string>();
             }
 
-            Attachments[workItemId].AddRange(fileList);
+            Attachments[workItemId].AddRange(fileList.Select(f => f.FilePath));
         }
 
         public void CacheWorkItem(int workItemId)
@@ -54,7 +54,7 @@ namespace Mail2Bug.WorkItemManagement
             WorkItemsCache[conversationId] = workItemId;
         }
 
-        public int CreateWorkItem(Dictionary<string, string> values)
+        public int CreateWorkItem(Dictionary<string, string> values, MessageAttachmentCollection attachments)
         {
             if (ThrowOnCreateBug != null) throw ThrowOnCreateBug;
 
@@ -80,7 +80,7 @@ namespace Mail2Bug.WorkItemManagement
             return id;
         }
 
-        public void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values)
+        public void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values, MessageAttachmentCollection attachments)
         {
             if (ThrowOnModifyBug != null) throw ThrowOnModifyBug;
 

--- a/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
+++ b/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
@@ -80,7 +80,7 @@ namespace Mail2Bug.WorkItemManagement
             return id;
         }
 
-        public void ModifyWorkItem(int workItemId, string comment, Dictionary<string, string> values)
+        public void ModifyWorkItem(int workItemId, string comment, bool commentIsHtml, Dictionary<string, string> values)
         {
             if (ThrowOnModifyBug != null) throw ThrowOnModifyBug;
 

--- a/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
+++ b/Mail2Bug/WorkItemManagement/WorkItemManagerMock.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using log4net;
+using Mail2Bug.Email;
 using Mail2Bug.MessageProcessingStrategies;
 
 namespace Mail2Bug.WorkItemManagement

--- a/Mail2Bug/packages.config
+++ b/Mail2Bug/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CsQuery" version="1.3.4" targetFramework="net45" />
   <package id="Hyak.Common" version="1.0.2" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />

--- a/Mail2BugUnitTests/AckTemplateUnitTest.cs
+++ b/Mail2BugUnitTests/AckTemplateUnitTest.cs
@@ -130,7 +130,7 @@ namespace Mail2BugUnitTests
 
             fields["Assigned To"] = null;
             fields["Priority"] = null;
-            var placeholdersWithDefaults = placeholders.Where(p => p.Field.Equals("BugOwner") || p.Field.Equals("Priority"));
+            var placeholdersWithDefaults = placeholders.Where(p => p.Field.Equals("BugOwner") || p.Field.Equals("Priority")).ToList();
             Assert.AreEqual(2, placeholdersWithDefaults.Count(), "Bad test data; all expected placeholders not found.");
 
             var workItem = new WorkItemFieldsMock(fields);

--- a/Mail2BugUnitTests/EmailBodyProcessingUtilsUnitTest.cs
+++ b/Mail2BugUnitTests/EmailBodyProcessingUtilsUnitTest.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Mail2Bug.Email;
-using Mail2Bug.MessageProcessingStrategies;
 using Mail2Bug.TestHelpers;
 using Mail2BugUnitTests.Mocks.Email;
 using Microsoft.Test.Text;

--- a/Mail2BugUnitTests/EmailBodyProcessingUtilsUnitTest.cs
+++ b/Mail2BugUnitTests/EmailBodyProcessingUtilsUnitTest.cs
@@ -31,7 +31,7 @@ namespace Mail2BugUnitTests
             }
             message.PlainTextBody = bodyBuilder.ToString();
 
-            Assert.AreEqual(lastMessageText, EmailBodyProcessingUtils.GetLastMessageText(message), "Verifying extracted last message text correctness");
+            Assert.AreEqual(lastMessageText, EmailBodyProcessingUtils.GetLastMessageText(message, true), "Verifying extracted last message text correctness");
         }
 
         [TestMethod]
@@ -94,7 +94,7 @@ namespace Mail2BugUnitTests
 </body></html>";
 
             string actual = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(original, attachmentInfo);
-            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(Normalize(expected), Normalize(actual));
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ This is a boring email.
 </body></html>";
 
             string actual = EmailBodyProcessingUtils.GetLastMessageText_Html(original);
-            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(Normalize(expected), Normalize(actual));
         }
 
         [TestMethod]
@@ -153,7 +153,7 @@ This is a boring email.
             <p class=""customStyling""><b></b></p></div></div></div></body></html>";
 
             string actual = EmailBodyProcessingUtils.GetLastMessageText_Html(original);
-            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(Normalize(expected), Normalize(actual));
         }
 
         private static string Normalize(string text)

--- a/Mail2BugUnitTests/EmailBodyProcessingUtilsUnitTest.cs
+++ b/Mail2BugUnitTests/EmailBodyProcessingUtilsUnitTest.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using Mail2Bug.Email;
+using Mail2Bug.MessageProcessingStrategies;
 using Mail2Bug.TestHelpers;
 using Mail2BugUnitTests.Mocks.Email;
 using Microsoft.Test.Text;
@@ -69,6 +71,90 @@ namespace Mail2BugUnitTests
 
                 Assert.AreEqual(expectedText, convertedHtml);
             }
+        }
+
+        [TestMethod]
+        public void TestUpdateEmbeddedImageLinks_Basic()
+        {
+            string original = @"<html>
+<body>
+<img src=""cid:123"" >
+</body>
+</html>";
+
+            IReadOnlyCollection<MessageAttachmentInfo> attachmentInfo = new List<MessageAttachmentInfo>
+            {
+                new MessageAttachmentInfo(@"x:\image.png", "123"),
+            };
+
+            // Note: it's acceptable to not preserve whitespace / insert empty HTML tags because we're
+            // manipulating HTML, not plain text. As long as the rendered page isn't impacted, all is well
+            string expected = @"<html><head></head><body>
+<img src=""file:///x:/image.png"">
+
+</body></html>";
+
+            string actual = EmailBodyProcessingUtils.UpdateEmbeddedImageLinks(original, attachmentInfo);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestGetLastMessageText_NoPrevious()
+        {
+            string original = @"<html>
+<body>
+This is a boring email.
+</body>
+</html>";
+
+            // Note: it's acceptable to not preserve whitespace / insert empty HTML tags because we're
+            // manipulating HTML, not plain text. As long as the rendered page isn't impacted, all is well
+            string expected = @"<html><head></head><body>
+This is a boring email.
+
+</body></html>";
+
+            string actual = EmailBodyProcessingUtils.GetLastMessageText_Html(original);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void TestGetLastMessageText_Previous_FromColon()
+        {
+            string original = @"<html>
+<body>
+<div class=""wrapppingBothMessageAndReply"">
+    <p class=""customStyling"">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p>
+    <div>
+        <div style=""border:none;border-top:solid"">
+            <p class=""customStyling""><b>From:</b> someAddress;<br><b>Subject:</b> RE: Build error<o:p></o:p>
+            </p>
+        </div>
+    </div>
+    <p class=""customStyling"">
+        <o:p>&nbsp;</o:p>
+    </p>
+    <p class=""customStyling"">text of the reply
+    </p>
+</div>
+<div>Something after the containing div</div>
+</body>
+</html>";
+
+            // Note: it's acceptable to not preserve whitespace because it's
+            // manipulating HTML, not plain text. As long as the rendered page isn't impacted, all is well
+            // Note that we expect that both
+            // 1. Elements following the latest message are removed
+            // 2. Anything in the same element as the latest message but after the start of the previous should be cleared out
+            string expected = @"<html><head></head><body>
+<div class=""wrapppingBothMessageAndReply"">
+    <p class=""customStyling"">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p>
+    <div>
+        <div style=""border:none;border-top:solid"">
+            <p class=""customStyling""><b></b></p></div></div></div></body></html>";
+
+            string actual = EmailBodyProcessingUtils.GetLastMessageText_Html(original);
+            Assert.AreEqual(expected, actual);
         }
 
         private static string Normalize(string text)

--- a/Mail2BugUnitTests/Mocks/Email/IncomingAttachmentMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingAttachmentMock.cs
@@ -37,6 +37,8 @@ namespace Mail2BugUnitTests.Mocks.Email
             return filename;
         }
 
+        public string ContentId { get; set; }
+
         public Exception ExceptionToThrow { get; set; }
         public byte[] Data = new byte[1];
 

--- a/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
+++ b/Mail2BugUnitTests/Mocks/Email/IncomingEmailMessageMock.cs
@@ -49,7 +49,7 @@ namespace Mail2BugUnitTests.Mocks.Email
             mock.CcNames = GetRandomNamesList(mock.CcAddresses.Count());
             mock.SentOn = new DateTime(Rand.Next(2012, 2525), Rand.Next(1, 12), Rand.Next(1, 28));
             mock.ReceivedOn = new DateTime(Rand.Next(2012, 2525), Rand.Next(1, 12), Rand.Next(1, 28));
-            mock.IsHtmlBody = Rand.Next(0, 1) == 0;
+            mock.IsHtmlBody = false; // this isn't html unless the creator specifically makes it so
 
             var attachments = new List<IIncomingEmailAttachment>(numAttachments);
             for (var i = 0; i < numAttachments; i++)
@@ -103,9 +103,9 @@ namespace Mail2BugUnitTests.Mocks.Email
             return filename;
         }
 
-        public string GetLastMessageText()
+        public string GetLastMessageText(bool enableExperimentalHtmlFeatures)
         {
-            return EmailBodyProcessingUtils.GetLastMessageText(this);
+            return EmailBodyProcessingUtils.GetLastMessageText(this, enableExperimentalHtmlFeatures);
         }
 
         public void CopyToFolder(string destinationFolder)

--- a/Mail2BugUnitTests/SimpleBugStrategyUnitTest.cs
+++ b/Mail2BugUnitTests/SimpleBugStrategyUnitTest.cs
@@ -201,7 +201,7 @@ namespace Mail2BugUnitTests
             {
                 expectedValues["Changed By"] = message3.SenderName;
             }
-            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText());
+            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(message2.GetLastMessageText(true) + message3.GetLastMessageText(true));
 
             ValidateBugValues(expectedValues, bugFields);
         }
@@ -249,7 +249,7 @@ namespace Mail2BugUnitTests
 
             expectedValues["Changed By"] = message4.SenderName;
             expectedValues[WorkItemManagerMock.HistoryField] = 
-                TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText() + message4.GetLastMessageText());
+                TextUtils.FixLineBreaks(message2.GetLastMessageText(true) + message3.GetLastMessageText(true) + message4.GetLastMessageText(true));
             expectedValues[mnemonicDef.Field] = mnemonicDef.Value;
             expectedValues[explicitOverride1.Key] = explicitOverride1.Value;
 
@@ -284,7 +284,7 @@ namespace Mail2BugUnitTests
 
             expectedValues["Changed By"] = message3.SenderName;
             expectedValues[WorkItemManagerMock.HistoryField] = 
-                TextUtils.FixLineBreaks(message2.GetLastMessageText() + message3.GetLastMessageText());
+                TextUtils.FixLineBreaks(message2.GetLastMessageText(true) + message3.GetLastMessageText(true));
 
             ValidateBugValues(expectedValues, bugFields);
 
@@ -325,7 +325,7 @@ namespace Mail2BugUnitTests
 
             var expectedValues = new Dictionary<string, string>();
             expectedValues["Changed By"] = appendOnlyMessage.SenderName;
-            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(appendOnlyMessage.GetLastMessageText());
+            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(appendOnlyMessage.GetLastMessageText(false));
 
             Assert.AreEqual(2, workItemManagerMock.Bugs.Count, "Only one bug should exist");
             ValidateBugValues(expectedValues, workItemManagerMock.Bugs[newBugId]);
@@ -388,7 +388,7 @@ namespace Mail2BugUnitTests
 
             var expectedValues = new Dictionary<string, string>();
             expectedValues["Changed By"] = appendOnlyMessage.SenderName;
-            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(appendOnlyMessage.GetLastMessageText());
+            expectedValues[WorkItemManagerMock.HistoryField] = TextUtils.FixLineBreaks(appendOnlyMessage.GetLastMessageText(true));
 
             Assert.AreEqual(2, workItemManagerMock.Bugs.Count, "Only one bug should exist");
             ValidateBugValues(expectedValues, workItemManagerMock.Bugs[newBugId]);


### PR DESCRIPTION
1. Preserves HTML in replies when adding comments to work items
2. For both replies and the original description (if the description is configured to be html), ensure that any embedded <img> tags in the original email HTML are preserved and rendered correctly in the work item
3. Numbers 1 & 2 are both gated behind a new config settings (EnableExperimentalHtmlFeatures)
4. Number 2 currently requires including attachments when first creating the work item rather than in subsequent edits.