### PR TITLE
Fix email separators from mobile and web clients

### DIFF
--- a/Mail2Bug/Email/EmailBodyProcessingUtils.cs
+++ b/Mail2Bug/Email/EmailBodyProcessingUtils.cs
@@ -43,7 +43,7 @@ namespace Mail2Bug.Email
                 // Lots of email clients insert html elements as message delimiters which have styling but no inner text
                 // This block checks for some of these patterns
                 if (string.Equals(element.NodeName, "div", StringComparison.OrdinalIgnoreCase) &&
-                    outlookDesktopSeparatorStyle.Equals(element.GetAttribute("style")))
+                   (element.Id == "divRplyFwdMsg" || element.Id == "x_divRplyFwdMsg" || outlookDesktopSeparatorStyle.Equals(element.GetAttribute("style"))))
                 {
                     IDomContainer parent = element.ParentNode;
                     RemoveSubsequent(parent);

--- a/Mail2BugUnitTests/LastMessageSchemas/FromColon.expected
+++ b/Mail2BugUnitTests/LastMessageSchemas/FromColon.expected
@@ -1,0 +1,6 @@
+﻿<html><head></head><body>
+<div class="wrapppingBothMessageAndReply">
+    <p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p>
+    <div>
+        <div style="border:none;border-top:solid">
+            <p class="customStyling"><b></b></p></div></div></div></body></html>

--- a/Mail2BugUnitTests/LastMessageSchemas/FromColon.orig
+++ b/Mail2BugUnitTests/LastMessageSchemas/FromColon.orig
@@ -1,0 +1,19 @@
+﻿<html>
+<body>
+<div class="wrapppingBothMessageAndReply">
+    <p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p>
+    <div>
+        <div style="border:none;border-top:solid">
+            <p class="customStyling"><b>From:</b> someAddress;<br><b>Subject:</b> RE: Build error<o:p></o:p>
+            </p>
+        </div>
+    </div>
+    <p class="customStyling">
+        <o:p>&nbsp;</o:p>
+    </p>
+    <p class="customStyling">text of the reply
+    </p>
+</div>
+<div>Something after the containing div</div>
+</body>
+</html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.expected
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.expected
@@ -1,0 +1,4 @@
+﻿<html><head></head><body>
+<div class="wrappingBothMessageAndReply">
+  <b><p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p></b>
+  </div></body></html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.orig
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookDesktopSeparator.orig
@@ -1,0 +1,18 @@
+﻿<html>
+<body>
+<div class="wrappingBothMessageAndReply">
+  <b><p class="customStyling">This is random text with some custom styling and outlook-generated elements.<o:p></o:p></p></b>
+  <div>
+    <div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0in 0in 0in">
+      <p class="customStyling">
+        <b>Old emails from: field and subject</b>
+      </p>
+    </div>
+  </div>
+  <p class="customStyling"><o:p>&nbsp;</o:p></p>
+  <div>
+      Something after the containing div
+  </div>
+</div>
+</body>
+</html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.expected
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.expected
@@ -1,0 +1,10 @@
+﻿<html><head></head>
+<body>
+<div>
+  <div>
+    <div style="customStyle">Message content from iPhone</div>
+  </div>
+  <div><br></div>
+  <div class="ms-outlook-ios-signature"></div>
+</div>
+</body></html>

--- a/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.orig
+++ b/Mail2BugUnitTests/LastMessageSchemas/OutlookMobileSeparator.orig
@@ -1,0 +1,15 @@
+﻿<html><head></head>
+<body>
+<div>
+  <div>
+    <div style="customStyle">Message content from iPhone</div>
+  </div>
+  <div><br /></div>
+  <div class="ms-outlook-ios-signature"></div>
+</div>
+<hr style="display:inline-block;width:98%" tabindex="-1" />
+<div>
+    Something after the containing div
+</div>
+</body>
+</html>

--- a/Mail2BugUnitTests/Mail2BugUnitTests.csproj
+++ b/Mail2BugUnitTests/Mail2BugUnitTests.csproj
@@ -82,6 +82,24 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="LastMessageSchemas\FromColon.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\FromColon.orig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookDesktopSeparator.orig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookMobileSeparator.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookMobileSeparator.orig">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="LastMessageSchemas\OutlookDesktopSeparator.expected">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="RegressionMessages\Basic.expected">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Different html schemas for outgoing emails produced parsing errors for emails sent from a mobile or web client. When the experimental html features were enabled, this produced that full email threads were added as a comment in ADO, instead of just the latest message.